### PR TITLE
feat: Add encryption flag to sensitive fields

### DIFF
--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -16638,6 +16638,7 @@ components:
           example: "123"
           maxLength: 4
           type: string
+          x-encripted: true
         device_fingerprint:
           description: It is a value that allows identifying the device fingerprint.
           example: zptcxk4p6w1ijwz85snf1l3bqe5g09ie
@@ -16662,6 +16663,7 @@ components:
           description: It is a value that allows identifying the number of the card.
           example: "4242424242424242"
           type: string
+          x-encripted: true
       required:
       - cvc
       - exp_month

--- a/schemas/tokens/token.yml
+++ b/schemas/tokens/token.yml
@@ -17,6 +17,7 @@ properties:
         description: "It is a value that allows identifying the security code of the card."
         example: "123"
         maxLength: 4
+        x-encripted: true
       device_fingerprint: 
         type: string
         description: "It is a value that allows identifying the device fingerprint."
@@ -39,6 +40,7 @@ properties:
         type: string
         description: "It is a value that allows identifying the number of the card."
         example: "4242424242424242"
+        x-encripted: true
   checkout:
     deprecated: true
     type: object


### PR DESCRIPTION
This commit adds the `x-encripted` flag to the `cvv` and `card_number` fields in both the `api.yaml` and `token.yml` files. This flag indicates that these fields should be encrypted for security purposes.