### PR TITLE
Add date_of_birth and national_id parameters to customer schemas

### DIFF
--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -12571,6 +12571,11 @@ components:
           description: Custom reference
           example: custom_reference
           type: string
+        date_of_birth:
+          description: It is a parameter that allows to identify the date of birth
+            of the client.
+          example: 24/07/1992
+          type: string
         default_fiscal_entity_id:
           example: fis_ent_2tKqqAfqPi21oCmEJ
           nullable: true
@@ -12600,6 +12605,11 @@ components:
         name:
           description: Customer's name
           example: Felipe
+          type: string
+        national_id:
+          description: It is a parameter that allows to identify the national identification
+            number of the client.
+          example: HEGG560427MVZRRL04
           type: string
         metadata:
           additionalProperties: true
@@ -13829,6 +13839,11 @@ components:
         custom_reference:
           description: It is an undefined value.
           type: string
+        date_of_birth:
+          description: It is a parameter that allows to identify the date of birth
+            of the client.
+          example: 24/07/1992
+          type: string
         email:
           description: "An email address is a series of customizable characters followed\
             \ by a universal Internet symbol, the at symbol (@), the name of a host\
@@ -13857,6 +13872,11 @@ components:
         name:
           description: Client's name
           example: miguel
+          type: string
+        national_id:
+          description: It is a parameter that allows to identify the national identification
+            number of the client.
+          example: HEGG560427MVZRRL04
           type: string
         payment_sources:
           description: Contains details of the payment methods that the customer has
@@ -13892,6 +13912,11 @@ components:
       properties:
         antifraud_info:
           $ref: '#/components/schemas/update_customer_antifraud_info'
+        date_of_birth:
+          description: It is a parameter that allows to identify the date of birth
+            of the client.
+          example: 24/07/1992
+          type: string
         default_payment_source_id:
           description: "It is a parameter that allows to identify in the response,\
             \ the Conekta ID of a payment method (payment_id)"
@@ -13938,6 +13963,11 @@ components:
           additionalProperties: true
           maxProperties: 100
           type: object
+        national_id:
+          description: It is a parameter that allows to identify the national identification
+            number of the client.
+          example: HEGG560427MVZRRL04
+          type: string
         payment_sources:
           description: Contains details of the payment methods that the customer has
             active or has used in Conekta

--- a/schemas/customers/customer.yml
+++ b/schemas/customers/customer.yml
@@ -26,6 +26,10 @@ properties:
   custom_reference:
     type: string
     description: It is an undefined value.
+  date_of_birth:
+    type: string
+    description: "It is a parameter that allows to identify the date of birth of the client."
+    example: "24/07/1992"
   email:
     type: string
     description: "An email address is a series of customizable characters followed by a universal Internet symbol, the at symbol (@), the name of a host server, and a web domain ending (.mx, .com, .org, . net, etc)."
@@ -51,6 +55,10 @@ properties:
     type: string
     description: Client's name
     example:  miguel
+  national_id:
+    type: string
+    description: "It is a parameter that allows to identify the national identification number of the client."
+    example: "HEGG560427MVZRRL04"
   payment_sources:
     description: Contains details of the payment methods that the customer has active or has used in Conekta
     type: array

--- a/schemas/customers/customer_response.yml
+++ b/schemas/customers/customer_response.yml
@@ -32,6 +32,10 @@ properties:
     type: string
     example: "custom_reference"
     description: Custom reference
+  date_of_birth:
+    type: string
+    description: "It is a parameter that allows to identify the date of birth of the client."
+    example: "24/07/1992"
   default_fiscal_entity_id:
     type: string
     nullable: true
@@ -92,6 +96,10 @@ properties:
     type: string
     example: Felipe
     description: Customer's name
+  national_id:
+    type: string
+    description: "It is a parameter that allows to identify the national identification number of the client."
+    example: "HEGG560427MVZRRL04"
   metadata:
     type: object
     additionalProperties: true

--- a/schemas/customers/update_customer.yml
+++ b/schemas/customers/update_customer.yml
@@ -13,6 +13,10 @@ properties:
       first_paid_at:
         type: integer
         example: 1485151007
+  date_of_birth:
+    type: string
+    description: "It is a parameter that allows to identify the date of birth of the client."
+    example: "24/07/1992"
   default_payment_source_id:
     type: string
     description: "It is a parameter that allows to identify in the response, the Conekta ID of a payment method (payment_id)"
@@ -53,6 +57,10 @@ properties:
     type: object
     additionalProperties: true
     maxProperties: 100
+  national_id:
+    type: string
+    description: "It is a parameter that allows to identify the national identification number of the client."
+    example: "HEGG560427MVZRRL04"
   payment_sources:
     description: Contains details of the payment methods that the customer has active or has used in Conekta
     type: array


### PR DESCRIPTION
- Added the "date_of_birth" parameter to the customer, customer_response, and update_customer schemas.
- The "date_of_birth" parameter allows identifying the date of birth of the client.
- Updated the descriptions and examples for the "date_of_birth" parameter in all affected schemas.
- Added the "national_id" parameter to the customer, customer_response, and update_customer schemas.
- The "national_id" parameter allows identifying the national identification number of the client.
- Updated the descriptions and examples for the "national_id" parameter in all affected schemas.
