### PR TITLE
feat: add excluded_payment_methods to checkout schemas

### DIFF
--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.1.2
 info:
   contact:
     email: engineering@conekta.com
@@ -18814,6 +18814,22 @@ components:
           items:
             type: string
           type: array
+        excluded_payment_methods:
+          description: Payment methods excluded from the checkout. This field is only
+            returned when excluded_payment_methods is provided in the request.
+          example:
+          - cash
+          - bank_transfer
+          items:
+            enum:
+            - cash
+            - card
+            - bank_transfer
+            - bnpl
+            - pay_by_bank
+            type: string
+          title: order_response_excluded_payment_methods
+          type: array
         can_not_expire:
           example: false
           type: boolean
@@ -18905,6 +18921,7 @@ components:
           description: "Redirection url back to the site in case of successful payment,\
             \ applies only to HostedPayment"
           example: http://187.216.228.66:2222/SysVentasPagos/Acceso.aspx
+          format: uri
           type: string
         starts_at:
           example: 1676354400
@@ -18924,10 +18941,11 @@ components:
           description: "Indicate the url of the Conekta component to complete the\
             \ payment. For HostedPayment, this will be a Conekta-hosted page"
           example: https://pay.conekta.io/checkout/6fca054a85194c43971ecea35cc519bb
+          format: uri
           type: string
       required:
-      - allowed_payment_methods
       - id
+      - livemode
       - name
       - object
       - type
@@ -19396,6 +19414,13 @@ components:
           example: 1676328434
           format: int64
           type: integer
+      required:
+      - amount
+      - created_at
+      - currency
+      - id
+      - livemode
+      - object
       title: order_response
     get_orders_response:
       allOf:
@@ -19441,7 +19466,8 @@ components:
       properties:
         allowed_payment_methods:
           description: "Are the payment methods available for this link. For subscriptions,\
-            \ only 'card' is allowed due to the recurring nature of the payments."
+            \ only 'card' is allowed due to the recurring nature of the payments.\
+            \ This field is mutually exclusive with excluded_payment_methods."
           example:
           - cash
           - card
@@ -19456,6 +19482,22 @@ components:
             - bnpl
             - pay_by_bank
             type: string
+          type: array
+        excluded_payment_methods:
+          description: Payment methods to be excluded from the checkout. This field
+            is mutually exclusive with allowed_payment_methods.
+          example:
+          - cash
+          - bank_transfer
+          items:
+            enum:
+            - cash
+            - card
+            - bank_transfer
+            - bnpl
+            - pay_by_bank
+            type: string
+          title: checkout_request_excluded_payment_methods
           type: array
         exclude_card_networks:
           description: List of card networks to exclude from the checkout. This field
@@ -19535,8 +19577,6 @@ components:
           - Integration
           - HostedPayment
           type: string
-      required:
-      - allowed_payment_methods
       title: order_checkout_request
     customer_info:
       properties:
@@ -20345,6 +20385,22 @@ components:
           items:
             type: string
           type: array
+        excluded_payment_methods:
+          description: Payment methods excluded from the checkout. This field is only
+            returned when excluded_payment_methods is provided in the request.
+          example:
+          - cash
+          - bank_transfer
+          items:
+            enum:
+            - cash
+            - card
+            - bank_transfer
+            - bnpl
+            - pay_by_bank
+            type: string
+          title: checkout_response_excluded_payment_methods
+          type: array
         plan_ids:
           description: List of plan IDs that are available for subscription
           example:
@@ -20544,7 +20600,7 @@ components:
       properties:
         allowed_payment_methods:
           description: Those are the payment methods that will be available for the
-            link
+            link. This field is mutually exclusive with excluded_payment_methods.
           example:
           - cash
           - card
@@ -20553,6 +20609,22 @@ components:
           - pay_by_bank
           items:
             type: string
+          type: array
+        excluded_payment_methods:
+          description: Payment methods to be excluded from the checkout. This field
+            is mutually exclusive with allowed_payment_methods.
+          example:
+          - cash
+          - bank_transfer
+          items:
+            enum:
+            - cash
+            - card
+            - bank_transfer
+            - bnpl
+            - pay_by_bank
+            type: string
+          title: checkout_excluded_payment_methods
           type: array
         exclude_card_networks:
           description: List of card networks to exclude from the checkout. This field
@@ -20641,7 +20713,6 @@ components:
           example: PaymentLink
           type: string
       required:
-      - allowed_payment_methods
       - expires_at
       - name
       - order_template

--- a/api.yaml
+++ b/api.yaml
@@ -1,4 +1,4 @@
-openapi: "3.1.0"
+openapi: "3.1.2"
 servers:
   - url: https://api.conekta.io
     description: Conekta main server

--- a/schemas/checkouts/checkout.yml
+++ b/schemas/checkouts/checkout.yml
@@ -2,7 +2,6 @@ title: checkout
 description: "It is a sub-resource of the Order model that can be stipulated in order to configure its corresponding checkout"
 type: object
 required:
-  - allowed_payment_methods
   - name
   - type
   - order_template
@@ -14,7 +13,15 @@ properties:
     items:
       type: string
     example: [ "cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
-    description: "Those are the payment methods that will be available for the link"
+    description: "Those are the payment methods that will be available for the link. This field is mutually exclusive with excluded_payment_methods."
+  excluded_payment_methods:
+    title: checkout_excluded_payment_methods
+    type: array
+    description: "Payment methods to be excluded from the checkout. This field is mutually exclusive with allowed_payment_methods."
+    items:
+      type: string
+      enum: ["cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
+    example: ["cash", "bank_transfer"]
   exclude_card_networks:
     title: checkout_exclude_card_networks
     type: array

--- a/schemas/checkouts/checkout_request.yml
+++ b/schemas/checkouts/checkout_request.yml
@@ -1,16 +1,22 @@
 title: order_checkout_request
 description: |
   [Checkout](https://developers.conekta.com/v2.3.0/reference/payment-link) details
-required:
-  - allowed_payment_methods
 properties:
   allowed_payment_methods:
     type: array
-    description: "Are the payment methods available for this link. For subscriptions, only 'card' is allowed due to the recurring nature of the payments."
+    description: "Are the payment methods available for this link. For subscriptions, only 'card' is allowed due to the recurring nature of the payments. This field is mutually exclusive with excluded_payment_methods."
     items:
       type: string
       enum: ["cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
     example: [ "cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
+  excluded_payment_methods:
+    title: checkout_request_excluded_payment_methods
+    type: array
+    description: "Payment methods to be excluded from the checkout. This field is mutually exclusive with allowed_payment_methods."
+    items:
+      type: string
+      enum: ["cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
+    example: ["cash", "bank_transfer"]
   exclude_card_networks:
     title: checkout_request_exclude_card_networks
     type: array

--- a/schemas/checkouts/checkout_response.yml
+++ b/schemas/checkouts/checkout_response.yml
@@ -13,6 +13,14 @@ properties:
       type: string
     example: [ "cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
     description: "Are the payment methods available for this link"
+  excluded_payment_methods:
+    title: checkout_response_excluded_payment_methods
+    type: array
+    items:
+      type: string
+      enum: ["cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
+    example: ["cash", "bank_transfer"]
+    description: "Payment methods excluded from the checkout. This field is only returned when excluded_payment_methods is provided in the request."
   plan_ids:
     type: array
     description: "List of plan IDs that are available for subscription"

--- a/schemas/orders/order_response.yml
+++ b/schemas/orders/order_response.yml
@@ -1,5 +1,12 @@
 title: order_response
 description: "order response"
+required:
+  - amount
+  - created_at
+  - currency
+  - id
+  - livemode
+  - object
 properties:
   amount:
     type: integer
@@ -42,8 +49,8 @@ properties:
   checkout:
     type: object
     required:
-      - allowed_payment_methods
       - id
+      - livemode
       - name
       - object
       - type
@@ -54,6 +61,14 @@ properties:
         description: "Are the payment methods available for this link"
         items:
           type: string
+      excluded_payment_methods:
+        title: order_response_excluded_payment_methods
+        type: array
+        items:
+          type: string
+          enum: ["cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
+        example: ["cash", "bank_transfer"]
+        description: "Payment methods excluded from the checkout. This field is only returned when excluded_payment_methods is provided in the request."
       can_not_expire:
         type: boolean
         example: false
@@ -139,6 +154,7 @@ properties:
         type: string
         description: "Redirection url back to the site in case of successful payment, applies only to HostedPayment"
         example: "http://187.216.228.66:2222/SysVentasPagos/Acceso.aspx"
+        format: uri
       starts_at:
         type: integer
         example: 1676354400
@@ -153,6 +169,7 @@ properties:
         type: string
         description: "Indicate the url of the Conekta component to complete the payment. For HostedPayment, this will be a Conekta-hosted page"
         example: "https://pay.conekta.io/checkout/6fca054a85194c43971ecea35cc519bb"
+        format: uri
   created_at:
     type: integer
     example: 1676328434


### PR DESCRIPTION
## Summary
- Remove `allowed_payment_methods` from required fields in checkout request schemas
- Add `excluded_payment_methods` array field (mutually exclusive with `allowed_payment_methods`) to checkout request, response, and order response schemas
- Supported values: `cash`, `card`, `bank_transfer`, `bnpl`, `pay_by_bank`
- `excluded_payment_methods` only returns in the response when provided in the request
- Update OpenAPI version to 3.1.2
- Add required fields and `format: uri` to order_response schema

## Test plan
- [ ] Verify `make merge` generates valid `_build/api.yaml`
- [ ] Validate spec passes `openapi-generator-cli validate`
- [ ] Confirm no auto-generated schema names in CI check
- [ ] Test checkout creation with only `excluded_payment_methods` (no `allowed_payment_methods`)
- [ ] Test that sending both fields returns appropriate error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)