### PR TITLE
Update OpenAPI schemas and Dockerfile for new payment methods (#118)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           generator: openapi-yaml
           openapi-file: api.yaml
-          generator-tag: v7.21.0
+          generator-tag: v7.23.0
       - name: check if api.yaml are equals
         run: |
           if diff -q _build/api.yaml openapi-yaml-client/openapi/openapi.yaml >/dev/null; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM public.ecr.aws/docker/library/node:24 AS builder
+FROM public.ecr.aws/docker/library/node:26 AS builder
 
 # Install OpenJDK-17
 RUN apt-get update && \
-    apt-get install -y openjdk-17-jre-headless && \
+    apt-get install -y openjdk-21-jre-headless && \
     apt-get clean;
 
 RUN npm install @openapitools/openapi-generator-cli -g
-RUN openapi-generator-cli version-manager set 7.21.0
+RUN openapi-generator-cli version-manager set 7.23.0
 WORKDIR /app
 
 COPY parameters/ parameters/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 merge:
 	docker run --rm \
-	-v ${PWD}:/local openapitools/openapi-generator-cli:v7.21.0 generate \
+	-v ${PWD}:/local openapitools/openapi-generator-cli:v7.23.0 generate \
 	-g openapi-yaml \
 	-i /local/api.yaml \
 	-p outputFile=local/_build/api.yaml \

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -2578,6 +2578,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/CompanyDocumentResponse"
                 type: array
+                default: null
           description: A list of documents for the company.
           headers:
             Date:
@@ -5180,6 +5181,27 @@ paths:
                       additionalProp1: {}
                       additionalProp2: {}
                       additionalProp3: {}
+              order_with_checkout_and_force_save_card:
+                summary: Create an order with checkout and force save card
+                value:
+                  checkout:
+                    allowed_payment_methods:
+                    - card
+                    force_save_card: true
+                    name: Compra
+                    type: Integration
+                  currency: MXN
+                  customer_info:
+                    customer_id: cus_2n9g6x7q1w5k8v3a
+                  line_items:
+                    description: string
+                    sku: string
+                    name: Box of Cohiba S1s
+                    unit_price: 20000
+                    quantity: 1
+                    tags:
+                    - string
+                    brand: string
               order_with_subscription:
                 summary: Create an order with subscription plans
                 value:
@@ -15453,6 +15475,7 @@ components:
             items:
               $ref: "#/components/schemas/risk_rules_data"
             type: array
+            default: null
       title: risk_rules_list
     details_error:
       properties:
@@ -15476,6 +15499,7 @@ components:
             items:
               $ref: "#/components/schemas/details_error"
             type: array
+            default: null
       - properties:
           log_id:
             description: log id
@@ -15670,6 +15694,7 @@ components:
             items:
               $ref: "#/components/schemas/api_key_response"
             type: array
+            default: null
       title: get_api_keys_response
     api_key_request:
       properties:
@@ -15828,36 +15853,43 @@ components:
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
         cashout_retention_amount:
           description: The balance's cashout retention amount
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
         conekta_retention:
           description: The balance's conekta retention
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
         gateway:
           description: The balance's gateway
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
         pending:
           description: The balance's pending
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
         retained:
           description: The balance's retained
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
         retention_amount:
           description: The balance's retention amount
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
         target_collateral_amount:
           description: The balance's target collateral amount
           type: object
@@ -15866,11 +15898,13 @@ components:
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
         temporarily_retained:
           description: The balance's temporarily retained
           items:
             $ref: "#/components/schemas/balance_common_fiels_response"
           type: array
+          default: null
       title: balance_response
     charge_response_channel:
       properties:
@@ -15983,6 +16017,7 @@ components:
           fraud_indicators:
             items: {}
             type: array
+            default: null
           issuer:
             description: Issuer of the card
             example: BANAMEX
@@ -16046,6 +16081,7 @@ components:
           payment_attempts:
             items: {}
             type: array
+            default: null
           receiving_account_holder_name:
             type: string
             nullable: true
@@ -16244,6 +16280,7 @@ components:
             items:
               $ref: "#/components/schemas/charge_response_refunds_data"
             type: array
+            default: null
       title: charge_response_refunds
       nullable: true
     chargeback_file_response:
@@ -16333,6 +16370,7 @@ components:
           items:
             $ref: "#/components/schemas/chargeback_file_response"
           type: array
+          default: null
         object:
           example: chargeback
           type: string
@@ -16457,6 +16495,7 @@ components:
             items:
               $ref: "#/components/schemas/charge_response"
             type: array
+            default: null
       title: get_charges_response
     charge_update_request:
       description: requested field for update a charge
@@ -16743,6 +16782,7 @@ components:
         refunds:
           items: {}
           type: array
+          default: null
         status:
           example: pending_payment
           type: string
@@ -16781,6 +16821,7 @@ components:
             items:
               $ref: "#/components/schemas/charge_response"
             type: array
+            default: null
       description: The charges associated with the order
       title: charges_order_response
     company_document_response:
@@ -16855,6 +16896,7 @@ components:
           items:
             $ref: "#/components/schemas/company_document_response"
           type: array
+          default: null
         created_at:
           description: Timestamp of when the company was created.
           example: 1748968241
@@ -16922,6 +16964,7 @@ components:
             items:
               $ref: "#/components/schemas/company_response"
             type: array
+            default: null
       title: get_companies_response
     Create_Company_Request_comercial_info:
       description: Commercial information for the company.
@@ -16982,10 +17025,10 @@ components:
     CompanyDocumentRequest:
       description: Request body for uploading a company document.
       example:
-        content_type: application/pdf
-        file_name: example_document.pdf
         file_classification: id_legal_representative
+        content_type: application/pdf
         international: false
+        file_name: example_document.pdf
         file_data: VGhpcyBpcyBhIHRlc3QgZmlsZSBkYXRhIGluIGJhc2UgNjQu
       properties:
         file_classification:
@@ -17194,6 +17237,7 @@ components:
             items:
               $ref: "#/components/schemas/customer_fiscal_entities_data_response"
             type: array
+            default: null
       title: customer_fiscal_entities_response
     cash_agreements_response:
       properties:
@@ -17235,6 +17279,7 @@ components:
             items:
               $ref: "#/components/schemas/cash_agreements_response"
             type: array
+            default: null
           reference:
             example: "93000262276908"
             type: string
@@ -17284,6 +17329,7 @@ components:
               items:
                 $ref: "#/components/schemas/cash_agreements_response"
               type: array
+              default: null
             reference:
               example: "93000262276908"
               type: string
@@ -17450,6 +17496,7 @@ components:
               $ref: "#/components/schemas/customer_payment_methods_data"
             title: customer_payment_methods_data
             type: array
+            default: null
         title: customerPaymentMethods
       title: customer_payment_methods_response
     customer_shipping_contacts_request_address:
@@ -17551,6 +17598,7 @@ components:
             items:
               $ref: "#/components/schemas/customer_shipping_contacts_data_response"
             type: array
+            default: null
     customer_subscription_response:
       description: subscription model
       properties:
@@ -17715,6 +17763,7 @@ components:
               $ref: "#/components/schemas/customer_response"
             title: customers_data_response
             type: array
+            default: null
       - description: pagination metadata
         properties:
           has_more:
@@ -17928,6 +17977,7 @@ components:
           items:
             $ref: "#/components/schemas/fiscal_entity_request"
           type: array
+          default: null
         metadata:
           additionalProperties: true
           maxProperties: 100
@@ -17947,6 +17997,7 @@ components:
           items:
             $ref: "#/components/schemas/customer_payment_methods_request"
           type: array
+          default: null
         phone:
           description: Is the customer's phone number
           example: "+5215555555555"
@@ -17962,6 +18013,7 @@ components:
           items:
             $ref: "#/components/schemas/customer_shipping_contacts_request"
           type: array
+          default: null
         subscription:
           $ref: "#/components/schemas/subscription_request"
       required:
@@ -18031,6 +18083,7 @@ components:
           items:
             $ref: "#/components/schemas/fiscal_entity_request"
           type: array
+          default: null
         metadata:
           additionalProperties: true
           maxProperties: 100
@@ -18046,12 +18099,14 @@ components:
           items:
             $ref: "#/components/schemas/customer_payment_methods_request"
           type: array
+          default: null
         shipping_contacts:
           description: Contains the detail of the shipping addresses that the client
             has active or has used in Conekta
           items:
             $ref: "#/components/schemas/customer_shipping_contacts_request"
           type: array
+          default: null
         subscription:
           $ref: "#/components/schemas/subscription_request"
       title: update_customer
@@ -18231,6 +18286,7 @@ components:
             items:
               $ref: "#/components/schemas/discount_lines_response"
             type: array
+            default: null
       title: get_order_discount_lines_response
     order_discount_lines_request:
       description: List of discounts that apply to the order.
@@ -18332,6 +18388,7 @@ components:
           items:
             $ref: "#/components/schemas/WebhookLog"
           type: array
+          default: null
         webhook_status:
           example: successful
           type: string
@@ -18370,6 +18427,7 @@ components:
             items:
               $ref: "#/components/schemas/event_response"
             type: array
+            default: null
       title: get_events_response
     resendEvent_request:
       properties:
@@ -18381,6 +18439,7 @@ components:
           items:
             type: string
           type: array
+          default: null
       required:
       - webhooks_ids
     events_resend_response:
@@ -18510,6 +18569,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         status:
           example: 200
           type: string
@@ -18551,6 +18611,7 @@ components:
             $ref: "#/components/schemas/logs_response_data"
           type: array
           nullable: true
+          default: null
       title: logs_response_for_request
     log_response_for_request:
       description: log model
@@ -18654,6 +18715,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         status:
           example: 200
           type: string
@@ -18800,6 +18862,7 @@ components:
             items:
               $ref: "#/components/schemas/charges_data_response"
             type: array
+            default: null
       description: The charges associated with the order
       title: order_charges_response
     order_response_checkout:
@@ -18812,9 +18875,12 @@ components:
           - bank_transfer
           - bnpl
           - pay_by_bank
+          - apple
+          - google
           items:
             type: string
           type: array
+          default: null
         can_not_expire:
           example: false
           type: boolean
@@ -18833,6 +18899,7 @@ components:
             type: string
           title: order_response_exclude_card_networks
           type: array
+          default: null
         expires_at:
           example: 1676613599
           format: int64
@@ -18843,6 +18910,12 @@ components:
         force_3ds_flow:
           example: false
           type: boolean
+        force_save_card:
+          description: Indicates whether the card used for the payment should be saved
+            for future purchases. This field is only applicable for card payments.
+          example: false
+          type: boolean
+          nullable: true
         id:
           example: 6fca054a-8519-4c43-971e-cea35cc519bb
           type: string
@@ -18871,6 +18944,7 @@ components:
             format: int8
             type: integer
           type: array
+          default: null
         name:
           example: ord-2tNDzhA4Akmzj11AS
           type: string
@@ -19045,6 +19119,7 @@ components:
             items:
               $ref: "#/components/schemas/discount_lines_data_response"
             type: array
+            default: null
       description: List of discounts that are applied to the order
       title: order_discount_lines_response
       nullable: true
@@ -19123,6 +19198,7 @@ components:
             items:
               $ref: "#/components/schemas/tax_lines_data_response"
             type: array
+            default: null
       description: List of taxes that are applied to the order
       title: order_tax_lines_response
       nullable: true
@@ -19202,6 +19278,7 @@ components:
             items:
               $ref: "#/components/schemas/shipping_lines_data_response"
             type: array
+            default: null
       description: List of shipping costs applied to the order
       title: order_shipping_lines_response
       nullable: true
@@ -19352,6 +19429,7 @@ components:
             items:
               type: string
             type: array
+            default: null
           unit_price:
             description: The price of the item in cents.
             example: 20000
@@ -19405,6 +19483,7 @@ components:
             items:
               $ref: "#/components/schemas/product_data_response"
             type: array
+            default: null
       title: order_response_products
     order_next_action_response_redirect_to_url:
       description: contains the following attributes that will guide to continue the
@@ -19599,6 +19678,7 @@ components:
             items:
               $ref: "#/components/schemas/order_response"
             type: array
+            default: null
         required:
         - data
         title: orders_response
@@ -19643,6 +19723,8 @@ components:
           - bank_transfer
           - bnpl
           - pay_by_bank
+          - google
+          - apple
           items:
             enum:
             - cash
@@ -19650,8 +19732,11 @@ components:
             - bank_transfer
             - bnpl
             - pay_by_bank
+            - google
+            - apple
             type: string
           type: array
+          default: null
         exclude_card_networks:
           description: List of card networks to exclude from the checkout. This field
             is only applicable for card payments.
@@ -19666,6 +19751,7 @@ components:
             type: string
           title: checkout_request_exclude_card_networks
           type: array
+          default: null
         plan_ids:
           description: List of plan IDs that will be available for subscription. This
             field is required for subscription payments.
@@ -19675,6 +19761,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         expires_at:
           description: "It is the time when the link will expire. \nIt is expressed\
             \ in seconds since the Unix epoch. The valid range is from 5 minutes to\
@@ -19688,6 +19775,11 @@ components:
           example: https://www.mysite.com/failure
           format: uri
           type: string
+        force_save_card:
+          description: Indicates whether the card used for the payment should be saved
+            for future purchases. This field is only applicable for card payments.
+          example: false
+          type: boolean
         monthly_installments_enabled:
           example: false
           type: boolean
@@ -19700,6 +19792,7 @@ components:
             format: int8
             type: integer
           type: array
+          default: null
         max_failed_retries:
           description: Number of retries allowed before the checkout is marked as
             failed
@@ -19891,6 +19984,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         unit_price:
           description: The price of the item in cents.
           example: 20000
@@ -19966,6 +20060,7 @@ components:
           items:
             $ref: "#/components/schemas/charge_request"
           type: array
+          default: null
         checkout:
           $ref: "#/components/schemas/order_checkout_request"
         currency:
@@ -19982,6 +20077,7 @@ components:
           items:
             $ref: "#/components/schemas/order_discount_lines_request"
           type: array
+          default: null
         fiscal_entity:
           $ref: "#/components/schemas/order_fiscal_entity_request"
         line_items:
@@ -19990,6 +20086,7 @@ components:
           items:
             $ref: "#/components/schemas/product"
           type: array
+          default: null
         metadata:
           additionalProperties: true
           description: Metadata associated with the order
@@ -20021,12 +20118,14 @@ components:
           items:
             $ref: "#/components/schemas/shipping_request"
           type: array
+          default: null
         tax_lines:
           description: "List of [taxes](https://developers.conekta.com/v2.2.0/reference/orderscreatetaxes)\
             \ that are applied to the order."
           items:
             $ref: "#/components/schemas/order_tax_request"
           type: array
+          default: null
         three_ds_mode:
           description: "Indicates the 3DS2 mode for the order, either smart or strict.\
             \ This property is only applicable when 3DS is enabled. When 3DS is disabled,\
@@ -20038,10 +20137,6 @@ components:
       - customer_info
       - line_items
       title: order_request
-    order_update_customer_info:
-      oneOf:
-      - $ref: "#/components/schemas/customer_info"
-      - $ref: "#/components/schemas/customer_info_customer_id"
     order_update_fiscal_entity_request:
       description: "Fiscal entity of the order, Currently it is a purely informative\
         \ field"
@@ -20081,6 +20176,7 @@ components:
           items:
             $ref: "#/components/schemas/charge_request"
           type: array
+          default: null
         checkout:
           $ref: "#/components/schemas/order_checkout_request"
         currency:
@@ -20090,13 +20186,14 @@ components:
           maxLength: 3
           type: string
         customer_info:
-          $ref: "#/components/schemas/order_update_customer_info"
+          $ref: "#/components/schemas/order_request_customer_info"
         discount_lines:
           description: "List of [discounts](https://developers.conekta.com/v2.2.0/reference/orderscreatediscountline)\
             \ that are applied to the order."
           items:
             $ref: "#/components/schemas/order_discount_lines_request"
           type: array
+          default: null
         fiscal_entity:
           $ref: "#/components/schemas/order_update_fiscal_entity_request"
         line_items:
@@ -20105,6 +20202,7 @@ components:
           items:
             $ref: "#/components/schemas/product"
           type: array
+          default: null
         metadata:
           additionalProperties:
             type: string
@@ -20119,10 +20217,12 @@ components:
           items:
             $ref: "#/components/schemas/shipping_request"
           type: array
+          default: null
         tax_lines:
           items:
             $ref: "#/components/schemas/order_tax_request"
           type: array
+          default: null
       title: order_update
     order_capture_request:
       properties:
@@ -20186,6 +20286,7 @@ components:
             items:
               type: string
             type: array
+            default: null
           unit_price:
             description: The price of the item in cents.
             example: 20000
@@ -20232,6 +20333,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         brand:
           type: string
         metadata:
@@ -20341,6 +20443,7 @@ components:
             type: string
           minItems: 1
           type: array
+          default: null
         amount:
           description: The amount of the payout order.
           example: 100
@@ -20388,6 +20491,7 @@ components:
             $ref: "#/components/schemas/payout_order_payouts_item"
           title: payout_order_payouts
           type: array
+          default: null
         reason:
           description: The reason for the payout order.
           example: Payout order for the customer
@@ -20424,6 +20528,7 @@ components:
               $ref: "#/components/schemas/payout_order_response"
             title: payout_orders_data_response
             type: array
+            default: null
       - description: pagination metadata
         properties:
           has_more:
@@ -20490,6 +20595,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         amount:
           description: The amount of the payout order.
           example: 100
@@ -20543,6 +20649,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         plan_ids:
           description: List of plan IDs that are available for subscription
           example:
@@ -20551,6 +20658,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         can_not_expire:
           example: false
           type: boolean
@@ -20569,6 +20677,7 @@ components:
             type: string
           title: checkout_response_exclude_card_networks
           type: array
+          default: null
         expires_at:
           example: 1680397724
           format: int64
@@ -20602,6 +20711,7 @@ components:
             format: int8
             type: integer
           type: array
+          default: null
         name:
           description: Reason for charge
           example: Payment Link Name 1594138857
@@ -20686,13 +20796,8 @@ components:
             items:
               $ref: "#/components/schemas/checkout_response"
             type: array
+            default: null
       title: checkouts_response
-    checkout_order_template_customer_info:
-      description: It is the information of the customer who will be created when
-        receiving a new payment.
-      oneOf:
-      - $ref: "#/components/schemas/customer_info"
-      - $ref: "#/components/schemas/customer_info_customer_id"
     checkout_order_template:
       description: It maintains the attributes with which the order will be created
         when receiving a new payment.
@@ -20704,7 +20809,7 @@ components:
           maxLength: 3
           type: string
         customer_info:
-          $ref: "#/components/schemas/checkout_order_template_customer_info"
+          $ref: "#/components/schemas/order_request_customer_info"
         line_items:
           description: They are the products to buy. Each contains the "unit price"
             and "quantity" parameters that are used to calculate the total amount
@@ -20712,6 +20817,7 @@ components:
           items:
             $ref: "#/components/schemas/product"
           type: array
+          default: null
         metadata:
           additionalProperties: true
           description: It is a set of key-value pairs that you can attach to the order.
@@ -20727,12 +20833,14 @@ components:
           items:
             $ref: "#/components/schemas/order_tax_request"
           type: array
+          default: null
         discount_lines:
           description: "List of [discounts](https://developers.conekta.com/v2.2.0/reference/orderscreatediscountline)\
             \ that are applied to the order."
           items:
             $ref: "#/components/schemas/order_discount_lines_request"
           type: array
+          default: null
       required:
       - currency
       - line_items
@@ -20752,6 +20860,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         exclude_card_networks:
           description: List of card networks to exclude from the checkout. This field
             is only applicable for card payments.
@@ -20766,6 +20875,7 @@ components:
             type: string
           title: checkout_exclude_card_networks
           type: array
+          default: null
         expires_at:
           description: "It is the time when the link will expire. \nIt is expressed\
             \ in seconds since the Unix epoch. The valid range is from 5 minutes to\
@@ -20790,6 +20900,7 @@ components:
             format: int8
             type: integer
           type: array
+          default: null
         three_ds_mode:
           description: "Indicates the 3DS2 mode for the order, either smart or strict.\
             \ This property is only applicable when 3DS is enabled. When 3DS is disabled,\
@@ -20818,6 +20929,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         order_template:
           $ref: "#/components/schemas/checkout_order_template"
         payments_limit_count:
@@ -20910,6 +21022,7 @@ components:
             items:
               $ref: "#/components/schemas/get_customer_payment_method_data_response"
             type: array
+            default: null
       title: get_payment_method_response
     CreateCustomerPaymentMethods_request:
       description: Contains details of the payment methods that the customer has active
@@ -21041,6 +21154,7 @@ components:
             items:
               $ref: "#/components/schemas/plan_response"
             type: array
+            default: null
       title: get_plans_response
     plan_request:
       description: a plan
@@ -21360,6 +21474,7 @@ components:
             items:
               $ref: "#/components/schemas/event_response"
             type: array
+            default: null
       title: subscription_events_response
     subscription_details_card:
       properties:
@@ -21665,6 +21780,7 @@ components:
             example: card
             type: string
           type: array
+          default: null
         can_not_expire:
           description: Indicates if the checkout can not expire.
           example: false
@@ -21678,6 +21794,7 @@ components:
             type: string
           title: token_response_exclude_card_networks
           type: array
+          default: null
         expires_at:
           description: Date and time when the checkout expires.
           example: 1675715413
@@ -21712,6 +21829,7 @@ components:
             example: 3
             type: integer
           type: array
+          default: null
         name:
           example: tok-2toNoPZpJgRU4PvgZ
           type: string
@@ -21890,6 +22008,7 @@ components:
             items:
               $ref: "#/components/schemas/transaction_response"
             type: array
+            default: null
       title: get_transactions_response
     transfer_method_response:
       description: Method used to make the transfer.
@@ -22011,6 +22130,7 @@ components:
             items:
               $ref: "#/components/schemas/transfers_response"
             type: array
+            default: null
       title: get_transfers_response
     transfer_destination_response:
       description: Method used to make the transfer.
@@ -22168,6 +22288,7 @@ components:
             items:
               $ref: "#/components/schemas/webhook_key_response"
             type: array
+            default: null
       title: get_webhook_keys_response
     webhook_key_request:
       properties:
@@ -22289,6 +22410,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         url:
           description: url or endpoint of the webhook
           example: https://username:password@mockoon.conekta.io/payments-api/cash/merchant_approval
@@ -22328,6 +22450,7 @@ components:
             items:
               $ref: "#/components/schemas/webhook_response"
             type: array
+            default: null
       title: get_webhooks_response
     webhook_request:
       description: a webhook
@@ -22346,6 +22469,7 @@ components:
           items:
             type: string
           type: array
+          default: null
       required:
       - url
       title: webhook_request
@@ -22366,6 +22490,7 @@ components:
           items:
             type: string
           type: array
+          default: null
         active:
           description: whether the webhook is active or not
           example: true

--- a/requestBodies/orders/order.yml
+++ b/requestBodies/orders/order.yml
@@ -12,6 +12,8 @@ content:
         $ref: '../../schemas/orders/request_examples/order_with_charges_pbb.yml'
       order_with_checkout:
         $ref: '../../schemas/orders/request_examples/order_with_checkout.yml'
+      order_with_checkout_and_force_save_card:
+        $ref: '../../schemas/orders/request_examples/order_with_checkout_and_force_save_card.yml'
       order_with_subscription:
         $ref: '../../schemas/orders/request_examples/order_with_subscription.yml'
       split_payment_with_2_card_charges:

--- a/schemas/checkouts/checkout_request.yml
+++ b/schemas/checkouts/checkout_request.yml
@@ -9,8 +9,8 @@ properties:
     description: "Are the payment methods available for this link. For subscriptions, only 'card' is allowed due to the recurring nature of the payments."
     items:
       type: string
-      enum: ["cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
-    example: [ "cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
+      enum: ["cash", "card", "bank_transfer", "bnpl", "pay_by_bank", 'google', 'apple']
+    example: [ "cash", "card", "bank_transfer", "bnpl", "pay_by_bank", "google", "apple"]
   exclude_card_networks:
     title: checkout_request_exclude_card_networks
     type: array
@@ -37,6 +37,10 @@ properties:
     format: uri
     description: "Redirection url back to the site in case of failed payment, applies only to HostedPayment."
     example: "https://www.mysite.com/failure"
+  force_save_card:
+    type: boolean
+    example: false
+    description: "Indicates whether the card used for the payment should be saved for future purchases. This field is only applicable for card payments."
   monthly_installments_enabled:
     type: boolean
     example: false

--- a/schemas/orders/order_response.yml
+++ b/schemas/orders/order_response.yml
@@ -50,7 +50,7 @@ properties:
     properties:
       allowed_payment_methods:
         type: array
-        example: [ "cash", "card", "bank_transfer", "bnpl", "pay_by_bank"]
+        example: [ "cash", "card", "bank_transfer", "bnpl", "pay_by_bank", "apple", "google"]
         description: "Are the payment methods available for this link"
         items:
           type: string
@@ -77,6 +77,11 @@ properties:
       force_3ds_flow:
         type: boolean
         example: false
+      force_save_card:
+        type: boolean
+        example: false
+        description: "Indicates whether the card used for the payment should be saved for future purchases. This field is only applicable for card payments."
+        nullable: true
       id:
         type: string
         example:  "6fca054a-8519-4c43-971e-cea35cc519bb"

--- a/schemas/orders/request_examples/order_with_checkout_and_force_save_card.yml
+++ b/schemas/orders/request_examples/order_with_checkout_and_force_save_card.yml
@@ -1,0 +1,20 @@
+summary: Create an order with checkout and force save card
+value:
+  checkout:
+    allowed_payment_methods:
+      - card
+    force_save_card: true
+    name: Compra
+    type: Integration
+  currency: MXN
+  customer_info:
+    customer_id: "cus_2n9g6x7q1w5k8v3a"
+  line_items:
+    description: string
+    sku: string
+    name: Box of Cohiba S1s
+    unit_price: 20000
+    quantity: 1
+    tags:
+    - string
+    brand: string


### PR DESCRIPTION
* feat: update OpenAPI schemas and Dockerfile to support new payment methods and force save card option

* fix: update OpenJDK version to 21 and remove nullable property from force_save_card in checkout request schema

* fix: update customer_info in order examples to use customer_id and remove unused fields