### PR TITLE
fix(orders): tighten shipping address, line, and item schema constraints

### DIFF
--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -1499,7 +1499,6 @@ paths:
               bnpl:
                 value:
                   payment_method:
-                    can_not_expire: true
                     cancel_url: https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/cancel
                     failure_url: https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/failure
                     product_type: aplazo_bnpl
@@ -1641,7 +1640,6 @@ paths:
               bnpl:
                 value:
                   payment_method:
-                    can_not_expire: true
                     cancel_url: https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/cancel
                     failure_url: https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/failure
                     product_type: aplazo_bnpl
@@ -5094,7 +5092,6 @@ paths:
                     checkout_request_type: PaymentLink
                   charges:
                   - payment_method:
-                      can_not_expire: true
                       cancel_url: https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/cancel
                       failure_url: https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/failure
                       product_type: aplazo_bnpl
@@ -16692,9 +16689,10 @@ components:
             minLength: 4
             type: string
           name:
-            description: Cardholder name. Must include first and last name separated
-              by a space; single-word names are rejected. Letters only — digits and
-              most symbols are rejected.
+            description: "Cardholder name. Must include first and last name separated\
+              \ by a space; single-word names are rejected. Letters (including accented\
+              \ Latin characters), spaces, and the characters , . ' - are accepted;\
+              \ digits and other symbols are rejected."
             example: John Doe
             maxLength: 249
             type: string
@@ -17656,7 +17654,10 @@ components:
             type: string
           between_streets:
             description: The street names between which the order will be delivered.
+              Must contain at least two consecutive ASCII letters.
             example: Ackerman Crescent
+            maxLength: 249
+            pattern: "[A-Za-z]{2}"
             type: string
           address:
             $ref: "#/components/schemas/customer_shipping_contacts_request_address"
@@ -18017,7 +18018,10 @@ components:
           type: string
         between_streets:
           description: The street names between which the order will be delivered.
+            Must contain at least two consecutive ASCII letters.
           example: Ackerman Crescent
+          maxLength: 249
+          pattern: "[A-Za-z]{2}"
           type: string
         address:
           $ref: "#/components/schemas/customer_shipping_contacts_request_address"
@@ -19279,7 +19283,7 @@ components:
             description:
               description: description or tax's name
               example: testing
-              minLength: 2
+              minLength: 3
               type: string
             metadata:
               additionalProperties:
@@ -20231,7 +20235,7 @@ components:
         description:
           description: description or tax's name
           example: testing
-          minLength: 2
+          minLength: 3
           type: string
         metadata:
           additionalProperties:
@@ -20322,14 +20326,14 @@ components:
           default: null
         three_ds_mode:
           description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'.\
-            \ The value is validated against the allowed set on creation. When this\
-            \ field is null the order defers to the company-level 3DS configuration."
+            \ The value is validated against the allowed set on creation; sending\
+            \ an explicit null is rejected. Omit the field to create the order without\
+            \ requesting 3DS through the API (company-level 3DS applies only to orders\
+            \ paid through Checkout or when antifraud forces 3DS)."
           enum:
           - strict
           - not_strict
           - smart
-          - null
-          nullable: true
           type: string
       required:
       - currency
@@ -21168,8 +21172,9 @@ components:
           default: null
         three_ds_mode:
           description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'.\
-            \ Accepted on creation only. When this field is null the checkout defers\
-            \ to the company-level 3DS configuration."
+            \ Accepted on creation only. Null appears in responses when no mode is\
+            \ configured; to defer to the company-level 3DS configuration, omit the\
+            \ field on creation (an explicit null is rejected)."
           enum:
           - strict
           - not_strict
@@ -21660,7 +21665,10 @@ components:
           type: string
         between_streets:
           description: The street names between which the order will be delivered.
+            Must contain at least two consecutive ASCII letters.
           example: Ackerman Crescent
+          maxLength: 249
+          pattern: "[A-Za-z]{2}"
           type: string
         address:
           $ref: "#/components/schemas/shipping_contact_address"
@@ -21989,7 +21997,7 @@ components:
           description:
             description: description or tax's name
             example: testing
-            minLength: 2
+            minLength: 3
             type: string
           metadata:
             additionalProperties:
@@ -22027,7 +22035,7 @@ components:
         description:
           description: description or tax's name
           example: testing
-          minLength: 2
+          minLength: 3
           type: string
         metadata:
           additionalProperties:

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -16623,13 +16623,15 @@ components:
         title: customer_payment_method_request
       - properties:
           cancel_url:
-            description: URL to redirect the customer after a canceled payment
+            description: Optional URL to redirect the customer after a canceled payment
             example: https://example.com/cancel
             type: string
-          can_not_expire:
-            description: Indicates if the payment method can not expire
-            example: true
-            type: boolean
+          expires_at:
+            description: "Optional expiry for the BNPL order, expressed in seconds\
+              \ since the Unix epoch"
+            example: 1680397724
+            format: int64
+            type: integer
           failure_url:
             description: URL to redirect the customer after a failed payment
             example: https://example.com/failure
@@ -16653,8 +16655,6 @@ components:
             example: bnpl
             type: string
         required:
-        - can_not_expire
-        - cancel_url
         - failure_url
         - product_type
         - success_url
@@ -16692,12 +16692,24 @@ components:
             minLength: 4
             type: string
           name:
-            description: Cardholder name
+            description: Cardholder name. Must include first and last name separated
+              by a space; single-word names are rejected.
             example: John Doe
+            maxLength: 249
             type: string
           number:
             description: Card number
             example: "4242424242424242"
+            type: string
+          contract_id:
+            description: Optional merchant-supplied identifier (exactly 10 characters)
+              that links a card transaction to a recurring/subscription contract at
+              the acquiring bank. Forwarded to the bank gateway and stored on the
+              resulting charge. Accepted on creation only; ignored on update. Do not
+              place sensitive bank data here — the value is returned in charge responses.
+            example: "3456788363"
+            maxLength: 10
+            minLength: 10
             type: string
           customer_ip_address:
             description: Optional field used to capture the customer's IP address
@@ -17245,10 +17257,6 @@ components:
             description: "this field follows the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)"
             example: MX
             type: string
-          residential:
-            default: false
-            example: true
-            type: boolean
           external_number:
             type: string
         required:
@@ -19247,6 +19255,13 @@ components:
             default: null
       description: List of discounts that are applied to the order
       nullable: true
+    order_tax_request_metadata_value:
+      oneOf:
+      - maxLength: 249
+        type: string
+      - type: integer
+      - type: number
+      - type: boolean
     tax_lines_data_response:
       allOf:
       - allOf:
@@ -19264,11 +19279,11 @@ components:
               minLength: 2
               type: string
             metadata:
-              additionalProperties: true
+              additionalProperties:
+                $ref: "#/components/schemas/order_tax_request_metadata_value"
               example:
                 key: value
               maxProperties: 100
-              type: object
           required:
           - amount
           - description
@@ -19354,13 +19369,14 @@ components:
               minLength: 3
               type: string
             metadata:
-              additionalProperties: true
-              description: Hash where the user can send additional information for
-                each 'shipping'.
+              additionalProperties:
+                $ref: "#/components/schemas/order_tax_request_metadata_value"
+              description: "Hash where the user can send additional information for\
+                \ each 'shipping'. Values must be scalar (string of at most 249 characters,\
+                \ integer, number or boolean); nested objects and arrays are rejected."
               example:
                 key: value
               maxProperties: 100
-              type: object
           required:
           - amount
           title: shipping_request
@@ -19529,14 +19545,15 @@ components:
             minLength: 3
             type: string
           metadata:
-            additionalProperties: true
+            additionalProperties:
+              $ref: "#/components/schemas/order_tax_request_metadata_value"
             default: {}
-            description: It is a key/value hash that can hold custom fields. Maximum
-              100 elements and allows special characters.
+            description: "It is a key/value hash that can hold custom fields. Maximum\
+              \ 100 elements. Values must be scalar (string of at most 249 characters,\
+              \ integer, number or boolean); nested objects and arrays are rejected."
             example:
               key: value
             maxProperties: 100
-            type: object
           name:
             description: The name of the item. It will be displayed in the order.
             example: Box of Cohiba S1s
@@ -19895,15 +19912,15 @@ components:
           type: array
           default: null
         exclude_card_networks:
-          description: List of card networks to exclude from the checkout. This field
-            is only applicable for card payments.
+          description: "List of card networks to exclude from the checkout. This field\
+            \ is only applicable for card payments. Accepted values: 'visa_master_card'\
+            \ (a single token excluding both Visa and Mastercard) and 'amex'. Values\
+            \ are echoed back in CamelCase (e.g. 'VisaMasterCard') in responses."
           example:
-          - visa
-          - amex
+          - visa_master_card
           items:
             enum:
-            - visa
-            - mastercard
+            - visa_master_card
             - amex
             type: string
           title: checkout_request_exclude_card_networks
@@ -20110,14 +20127,15 @@ components:
           minLength: 3
           type: string
         metadata:
-          additionalProperties: true
+          additionalProperties:
+            $ref: "#/components/schemas/order_tax_request_metadata_value"
           default: {}
-          description: It is a key/value hash that can hold custom fields. Maximum
-            100 elements and allows special characters.
+          description: "It is a key/value hash that can hold custom fields. Maximum\
+            \ 100 elements. Values must be scalar (string of at most 249 characters,\
+            \ integer, number or boolean); nested objects and arrays are rejected."
           example:
             key: value
           maxProperties: 100
-          type: object
         name:
           description: The name of the item. It will be displayed in the order.
           example: Box of Cohiba S1s
@@ -20188,13 +20206,14 @@ components:
           minLength: 3
           type: string
         metadata:
-          additionalProperties: true
-          description: Hash where the user can send additional information for each
-            'shipping'.
+          additionalProperties:
+            $ref: "#/components/schemas/order_tax_request_metadata_value"
+          description: "Hash where the user can send additional information for each\
+            \ 'shipping'. Values must be scalar (string of at most 249 characters,\
+            \ integer, number or boolean); nested objects and arrays are rejected."
           example:
             key: value
           maxProperties: 100
-          type: object
       required:
       - amount
       title: shipping_request
@@ -20213,11 +20232,11 @@ components:
           minLength: 2
           type: string
         metadata:
-          additionalProperties: true
+          additionalProperties:
+            $ref: "#/components/schemas/order_tax_request_metadata_value"
           example:
             key: value
           maxProperties: 100
-          type: object
       required:
       - amount
       - description
@@ -20259,10 +20278,12 @@ components:
           type: array
           default: null
         metadata:
-          additionalProperties: true
-          description: Metadata associated with the order
+          additionalProperties:
+            $ref: "#/components/schemas/order_tax_request_metadata_value"
+          description: "Metadata associated with the order. Values must be scalar\
+            \ (string of at most 249 characters, integer, number or boolean); nested\
+            \ objects and arrays are rejected."
           maxProperties: 100
-          type: object
         needs_shipping_contact:
           description: Allows you to fill out the shipping information at checkout
           example: false
@@ -20298,9 +20319,15 @@ components:
           type: array
           default: null
         three_ds_mode:
-          description: "Indicates the 3DS2 mode for the order, either smart or strict.\
-            \ This property is only applicable when 3DS is enabled. When 3DS is disabled,\
-            \ this field should be null."
+          description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'.\
+            \ Accepted on creation only. This property is only applicable when 3DS\
+            \ is enabled; when 3DS is disabled this field should be null (no 3DS flow\
+            \ is applied)."
+          enum:
+          - strict
+          - not_strict
+          - smart
+          - null
           nullable: true
           type: string
       required:
@@ -20381,7 +20408,8 @@ components:
           default: null
         metadata:
           additionalProperties:
-            type: string
+            $ref: "#/components/schemas/order_tax_request_metadata_value"
+          maxProperties: 100
         pre_authorize:
           description: Indicates whether the order charges must be preauthorized
           type: boolean
@@ -20432,14 +20460,15 @@ components:
             minLength: 3
             type: string
           metadata:
-            additionalProperties: true
+            additionalProperties:
+              $ref: "#/components/schemas/order_tax_request_metadata_value"
             default: {}
-            description: It is a key/value hash that can hold custom fields. Maximum
-              100 elements and allows special characters.
+            description: "It is a key/value hash that can hold custom fields. Maximum\
+              \ 100 elements. Values must be scalar (string of at most 249 characters,\
+              \ integer, number or boolean); nested objects and arrays are rejected."
             example:
               key: value
             maxProperties: 100
-            type: object
           name:
             description: The name of the item. It will be displayed in the order.
             example: Box of Cohiba S1s
@@ -20533,7 +20562,8 @@ components:
           type: string
         metadata:
           additionalProperties:
-            type: string
+            $ref: "#/components/schemas/order_tax_request_metadata_value"
+          maxProperties: 100
       title: update_product
     orderRefund_request:
       properties:
@@ -21097,16 +21127,18 @@ components:
           type: array
           default: null
         exclude_card_networks:
-          description: List of card networks to exclude from the checkout. This field
-            is only applicable for card payments.
+          description: "List of card networks to exclude from the checkout. This field\
+            \ is only applicable for card payments. Accepted request values: 'visa_master_card'\
+            \ (a single token excluding both Visa and Mastercard) and 'amex'. Responses\
+            \ echo the stored values in CamelCase (e.g. 'VisaMasterCard', 'Amex')."
           example:
-          - visa
-          - amex
+          - visa_master_card
           items:
             enum:
-            - visa
-            - mastercard
+            - visa_master_card
             - amex
+            - VisaMasterCard
+            - Amex
             type: string
           title: checkout_exclude_card_networks
           type: array
@@ -21137,9 +21169,15 @@ components:
           type: array
           default: null
         three_ds_mode:
-          description: "Indicates the 3DS2 mode for the order, either smart or strict.\
-            \ This property is only applicable when 3DS is enabled. When 3DS is disabled,\
-            \ this field should be null."
+          description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'.\
+            \ Accepted on creation only. This property is only applicable when 3DS\
+            \ is enabled; when 3DS is disabled this field should be null (no 3DS flow\
+            \ is applied)."
+          enum:
+          - strict
+          - not_strict
+          - smart
+          - null
           nullable: true
           type: string
         name:
@@ -21505,13 +21543,14 @@ components:
             minLength: 3
             type: string
           metadata:
-            additionalProperties: true
-            description: Hash where the user can send additional information for each
-              'shipping'.
+            additionalProperties:
+              $ref: "#/components/schemas/order_tax_request_metadata_value"
+            description: "Hash where the user can send additional information for\
+              \ each 'shipping'. Values must be scalar (string of at most 249 characters,\
+              \ integer, number or boolean); nested objects and arrays are rejected."
             example:
               key: value
             maxProperties: 100
-            type: object
         required:
         - amount
         title: shipping_request
@@ -21954,11 +21993,11 @@ components:
             minLength: 2
             type: string
           metadata:
-            additionalProperties: true
+            additionalProperties:
+              $ref: "#/components/schemas/order_tax_request_metadata_value"
             example:
               key: value
             maxProperties: 100
-            type: object
         required:
         - amount
         - description
@@ -21993,7 +22032,7 @@ components:
           type: string
         metadata:
           additionalProperties:
-            type: object
+            $ref: "#/components/schemas/order_tax_request_metadata_value"
           maxProperties: 100
     token_request_card:
       nullable: true

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -19376,7 +19376,7 @@ components:
                 $ref: "#/components/schemas/order_tax_request_metadata_value"
               description: "Hash where the user can send additional information for\
                 \ each 'shipping'. Values must be scalar (string of at most 249 characters,\
-                \ integer, number or boolean); nested objects and arrays are rejected."
+                \ integer, number or boolean); nested objects and arrays are not supported."
               example:
                 key: value
               maxProperties: 100
@@ -19553,7 +19553,7 @@ components:
             default: {}
             description: "It is a key/value hash that can hold custom fields. Maximum\
               \ 100 elements. Values must be scalar (string of at most 249 characters,\
-              \ integer, number or boolean); nested objects and arrays are rejected."
+              \ integer, number or boolean); nested objects and arrays are not supported."
             example:
               key: value
             maxProperties: 100
@@ -20134,7 +20134,7 @@ components:
           default: {}
           description: "It is a key/value hash that can hold custom fields. Maximum\
             \ 100 elements. Values must be scalar (string of at most 249 characters,\
-            \ integer, number or boolean); nested objects and arrays are rejected."
+            \ integer, number or boolean); nested objects and arrays are not supported."
           example:
             key: value
           maxProperties: 100
@@ -20212,7 +20212,7 @@ components:
             $ref: "#/components/schemas/order_tax_request_metadata_value"
           description: "Hash where the user can send additional information for each\
             \ 'shipping'. Values must be scalar (string of at most 249 characters,\
-            \ integer, number or boolean); nested objects and arrays are rejected."
+            \ integer, number or boolean); nested objects and arrays are not supported."
           example:
             key: value
           maxProperties: 100
@@ -20284,7 +20284,7 @@ components:
             $ref: "#/components/schemas/order_tax_request_metadata_value"
           description: "Metadata associated with the order. Values must be scalar\
             \ (string of at most 249 characters, integer, number or boolean); nested\
-            \ objects and arrays are rejected."
+            \ objects and arrays are not supported."
           maxProperties: 100
         needs_shipping_contact:
           description: Allows you to fill out the shipping information at checkout
@@ -20466,7 +20466,7 @@ components:
             default: {}
             description: "It is a key/value hash that can hold custom fields. Maximum\
               \ 100 elements. Values must be scalar (string of at most 249 characters,\
-              \ integer, number or boolean); nested objects and arrays are rejected."
+              \ integer, number or boolean); nested objects and arrays are not supported."
             example:
               key: value
             maxProperties: 100
@@ -21544,7 +21544,7 @@ components:
               $ref: "#/components/schemas/order_tax_request_metadata_value"
             description: "Hash where the user can send additional information for\
               \ each 'shipping'. Values must be scalar (string of at most 249 characters,\
-              \ integer, number or boolean); nested objects and arrays are rejected."
+              \ integer, number or boolean); nested objects and arrays are not supported."
             example:
               key: value
             maxProperties: 100

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -16628,7 +16628,7 @@ components:
             type: string
           expires_at:
             description: "Optional expiry for the BNPL order, expressed in seconds\
-              \ since the Unix epoch"
+              \ since the Unix epoch. Defaults to one month from creation when omitted."
             example: 1680397724
             format: int64
             type: integer
@@ -16693,7 +16693,8 @@ components:
             type: string
           name:
             description: Cardholder name. Must include first and last name separated
-              by a space; single-word names are rejected.
+              by a space; single-word names are rejected. Letters only — digits and
+              most symbols are rejected.
             example: John Doe
             maxLength: 249
             type: string
@@ -17610,9 +17611,11 @@ components:
             maxLength: 250
             type: string
           city:
-            description: City of the delivery address.
+            description: City of the delivery address. Must contain at least two consecutive
+              ASCII letters.
             example: Ciudad de Mexico
             maxLength: 249
+            pattern: "[A-Za-z]{2}"
             type: string
           state:
             description: State of the delivery address.
@@ -19256,7 +19259,7 @@ components:
       description: List of discounts that are applied to the order
       nullable: true
     order_tax_request_metadata_value:
-      oneOf:
+      anyOf:
       - maxLength: 249
         type: string
       - type: integer
@@ -19914,8 +19917,7 @@ components:
         exclude_card_networks:
           description: "List of card networks to exclude from the checkout. This field\
             \ is only applicable for card payments. Accepted values: 'visa_master_card'\
-            \ (a single token excluding both Visa and Mastercard) and 'amex'. Values\
-            \ are echoed back in CamelCase (e.g. 'VisaMasterCard') in responses."
+            \ (a single token excluding both Visa and Mastercard) and 'amex'."
           example:
           - visa_master_card
           items:
@@ -20320,9 +20322,8 @@ components:
           default: null
         three_ds_mode:
           description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'.\
-            \ Accepted on creation only. This property is only applicable when 3DS\
-            \ is enabled; when 3DS is disabled this field should be null (no 3DS flow\
-            \ is applied)."
+            \ The value is validated against the allowed set on creation. When this\
+            \ field is null the order defers to the company-level 3DS configuration."
           enum:
           - strict
           - not_strict
@@ -21128,17 +21129,14 @@ components:
           default: null
         exclude_card_networks:
           description: "List of card networks to exclude from the checkout. This field\
-            \ is only applicable for card payments. Accepted request values: 'visa_master_card'\
-            \ (a single token excluding both Visa and Mastercard) and 'amex'. Responses\
-            \ echo the stored values in CamelCase (e.g. 'VisaMasterCard', 'Amex')."
+            \ is only applicable for card payments. Accepted values: 'visa_master_card'\
+            \ (a single token excluding both Visa and Mastercard) and 'amex'."
           example:
           - visa_master_card
           items:
             enum:
             - visa_master_card
             - amex
-            - VisaMasterCard
-            - Amex
             type: string
           title: checkout_exclude_card_networks
           type: array
@@ -21170,9 +21168,8 @@ components:
           default: null
         three_ds_mode:
           description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'.\
-            \ Accepted on creation only. This property is only applicable when 3DS\
-            \ is enabled; when 3DS is disabled this field should be null (no 3DS flow\
-            \ is applied)."
+            \ Accepted on creation only. When this field is null the checkout defers\
+            \ to the company-level 3DS configuration."
           enum:
           - strict
           - not_strict
@@ -21623,9 +21620,11 @@ components:
           maxLength: 250
           type: string
         city:
-          description: City of the delivery address.
+          description: City of the delivery address. Must contain at least two consecutive
+            ASCII letters.
           example: Ciudad de Mexico
           maxLength: 249
+          pattern: "[A-Za-z]{2}"
           type: string
         state:
           description: State of the delivery address.

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -16622,14 +16622,12 @@ components:
           cancel_url:
             description: Optional URL to redirect the customer after a canceled payment
             example: https://example.com/cancel
-            nullable: true
             type: string
           expires_at:
             description: "Optional expiry for the BNPL order, expressed in seconds\
               \ since the Unix epoch. Defaults to one month from creation when omitted."
             example: 1680397724
             format: int64
-            nullable: true
             type: integer
           failure_url:
             description: URL to redirect the customer after a failed payment

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -16622,12 +16622,14 @@ components:
           cancel_url:
             description: Optional URL to redirect the customer after a canceled payment
             example: https://example.com/cancel
+            nullable: true
             type: string
           expires_at:
             description: "Optional expiry for the BNPL order, expressed in seconds\
               \ since the Unix epoch. Defaults to one month from creation when omitted."
             example: 1680397724
             format: int64
+            nullable: true
             type: integer
           failure_url:
             description: URL to redirect the customer after a failed payment

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -21174,15 +21174,12 @@ components:
           default: null
         three_ds_mode:
           description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'.\
-            \ Accepted on creation only. Null appears in responses when no mode is\
-            \ configured; to defer to the company-level 3DS configuration, omit the\
-            \ field on creation (an explicit null is rejected)."
+            \ To defer to the company-level 3DS configuration, omit the field (an\
+            \ explicit null is rejected on creation)."
           enum:
           - strict
           - not_strict
           - smart
-          - null
-          nullable: true
           type: string
         name:
           description: Reason for charge

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -17586,13 +17586,14 @@ components:
           street1:
             description: Street and number of the delivery address.
             example: Nuevo Leon 254
-            maxLength: 250
+            maxLength: 249
+            minLength: 2
             type: string
           street2:
             description: "Apartment, suite or interior reference for the delivery\
               \ address."
             example: Departamento 404
-            maxLength: 250
+            maxLength: 249
             type: string
           postal_code:
             description: Postal code of the delivery address. For Mexican addresses
@@ -17603,18 +17604,19 @@ components:
           city:
             description: City of the delivery address.
             example: Ciudad de Mexico
-            maxLength: 250
+            maxLength: 249
             type: string
           state:
             description: State of the delivery address.
             example: Ciudad de Mexico
-            maxLength: 250
+            maxLength: 249
             type: string
           country:
             description: "Country of the delivery address. This field follows the\
               \ [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)."
             example: MX
-            maxLength: 250
+            maxLength: 249
+            minLength: 2
             type: string
           residential:
             default: true
@@ -19336,17 +19338,20 @@ components:
             carrier:
               description: Carrier name for the shipment
               example: FEDEX
-              maxLength: 250
+              maxLength: 249
+              minLength: 3
               type: string
             tracking_number:
               description: Tracking number can be used to track the shipment
               example: TRACK123
-              maxLength: 250
+              maxLength: 249
+              minLength: 3
               type: string
             method:
               description: Method of shipment
               example: Same day
-              maxLength: 250
+              maxLength: 249
+              minLength: 3
               type: string
             metadata:
               additionalProperties: true
@@ -19514,12 +19519,14 @@ components:
           brand:
             description: The brand of the item.
             example: Cohiba
-            maxLength: 250
+            maxLength: 249
+            minLength: 2
             type: string
           description:
             description: Short description of the item
             example: Imported From Mex.
-            maxLength: 250
+            maxLength: 249
+            minLength: 3
             type: string
           metadata:
             additionalProperties: true
@@ -19533,7 +19540,8 @@ components:
           name:
             description: The name of the item. It will be displayed in the order.
             example: Box of Cohiba S1s
-            maxLength: 250
+            maxLength: 249
+            minLength: 3
             type: string
           quantity:
             description: The quantity of the item in the order.
@@ -19545,7 +19553,8 @@ components:
             description: The stock keeping unit for the item. It is used to identify
               the item in the order.
             example: XYZ12345
-            maxLength: 250
+            maxLength: 249
+            minLength: 1
             type: string
           tags:
             description: List of tags for the item. It is used to identify the item
@@ -19554,8 +19563,10 @@ components:
             - food
             - mexican food
             items:
-              maxLength: 250
+              maxLength: 249
+              minLength: 2
               type: string
+            minItems: 1
             type: array
             default: null
           unit_price:
@@ -20089,12 +20100,14 @@ components:
         brand:
           description: The brand of the item.
           example: Cohiba
-          maxLength: 250
+          maxLength: 249
+          minLength: 2
           type: string
         description:
           description: Short description of the item
           example: Imported From Mex.
-          maxLength: 250
+          maxLength: 249
+          minLength: 3
           type: string
         metadata:
           additionalProperties: true
@@ -20108,7 +20121,8 @@ components:
         name:
           description: The name of the item. It will be displayed in the order.
           example: Box of Cohiba S1s
-          maxLength: 250
+          maxLength: 249
+          minLength: 3
           type: string
         quantity:
           description: The quantity of the item in the order.
@@ -20120,7 +20134,8 @@ components:
           description: The stock keeping unit for the item. It is used to identify
             the item in the order.
           example: XYZ12345
-          maxLength: 250
+          maxLength: 249
+          minLength: 1
           type: string
         tags:
           description: List of tags for the item. It is used to identify the item
@@ -20129,8 +20144,10 @@ components:
           - food
           - mexican food
           items:
-            maxLength: 250
+            maxLength: 249
+            minLength: 2
             type: string
+          minItems: 1
           type: array
           default: null
         unit_price:
@@ -20155,17 +20172,20 @@ components:
         carrier:
           description: Carrier name for the shipment
           example: FEDEX
-          maxLength: 250
+          maxLength: 249
+          minLength: 3
           type: string
         tracking_number:
           description: Tracking number can be used to track the shipment
           example: TRACK123
-          maxLength: 250
+          maxLength: 249
+          minLength: 3
           type: string
         method:
           description: Method of shipment
           example: Same day
-          maxLength: 250
+          maxLength: 249
+          minLength: 3
           type: string
         metadata:
           additionalProperties: true
@@ -20402,12 +20422,14 @@ components:
           brand:
             description: The brand of the item.
             example: Cohiba
-            maxLength: 250
+            maxLength: 249
+            minLength: 2
             type: string
           description:
             description: Short description of the item
             example: Imported From Mex.
-            maxLength: 250
+            maxLength: 249
+            minLength: 3
             type: string
           metadata:
             additionalProperties: true
@@ -20421,7 +20443,8 @@ components:
           name:
             description: The name of the item. It will be displayed in the order.
             example: Box of Cohiba S1s
-            maxLength: 250
+            maxLength: 249
+            minLength: 3
             type: string
           quantity:
             description: The quantity of the item in the order.
@@ -20433,7 +20456,8 @@ components:
             description: The stock keeping unit for the item. It is used to identify
               the item in the order.
             example: XYZ12345
-            maxLength: 250
+            maxLength: 249
+            minLength: 1
             type: string
           tags:
             description: List of tags for the item. It is used to identify the item
@@ -20442,8 +20466,10 @@ components:
             - food
             - mexican food
             items:
-              maxLength: 250
+              maxLength: 249
+              minLength: 2
               type: string
+            minItems: 1
             type: array
             default: null
           unit_price:
@@ -20471,12 +20497,17 @@ components:
           additionalProperties:
             type: object
         description:
-          maxLength: 250
+          maxLength: 249
+          minLength: 3
           type: string
         sku:
+          maxLength: 249
+          minLength: 1
           type: string
         name:
           example: Box of Cohiba S1s
+          maxLength: 249
+          minLength: 3
           type: string
         unit_price:
           example: 20000
@@ -20490,10 +20521,15 @@ components:
           type: integer
         tags:
           items:
+            maxLength: 249
+            minLength: 2
             type: string
+          minItems: 1
           type: array
           default: null
         brand:
+          maxLength: 249
+          minLength: 2
           type: string
         metadata:
           additionalProperties:
@@ -21453,17 +21489,20 @@ components:
           carrier:
             description: Carrier name for the shipment
             example: FEDEX
-            maxLength: 250
+            maxLength: 249
+            minLength: 3
             type: string
           tracking_number:
             description: Tracking number can be used to track the shipment
             example: TRACK123
-            maxLength: 250
+            maxLength: 249
+            minLength: 3
             type: string
           method:
             description: Method of shipment
             example: Same day
-            maxLength: 250
+            maxLength: 249
+            minLength: 3
             type: string
           metadata:
             additionalProperties: true
@@ -21530,12 +21569,13 @@ components:
         street1:
           description: Street and number of the delivery address.
           example: Nuevo Leon 254
-          maxLength: 250
+          maxLength: 249
+          minLength: 2
           type: string
         street2:
           description: "Apartment, suite or interior reference for the delivery address."
           example: Departamento 404
-          maxLength: 250
+          maxLength: 249
           type: string
         postal_code:
           description: Postal code of the delivery address. For Mexican addresses
@@ -21546,18 +21586,19 @@ components:
         city:
           description: City of the delivery address.
           example: Ciudad de Mexico
-          maxLength: 250
+          maxLength: 249
           type: string
         state:
           description: State of the delivery address.
           example: Ciudad de Mexico
-          maxLength: 250
+          maxLength: 249
           type: string
         country:
           description: "Country of the delivery address. This field follows the [ISO\
             \ 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)."
           example: MX
-          maxLength: 250
+          maxLength: 249
+          minLength: 2
           type: string
         residential:
           default: true

--- a/_build/api.yaml
+++ b/_build/api.yaml
@@ -17580,31 +17580,53 @@ components:
         title: customerPaymentMethods
       title: customer_payment_methods_response
     customer_shipping_contacts_request_address:
-      description: Address of the person who will receive the order
-      properties:
-        street1:
-          example: Nuevo Leon 254
-          type: string
-        street2:
-          example: Departamento 404
-          type: string
-        postal_code:
-          example: "06100"
-          type: string
-        city:
-          example: Ciudad de Mexico
-          type: string
-        state:
-          example: Ciudad de Mexico
-          type: string
-        country:
-          description: "this field follows the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)"
-          example: MX
-          type: string
-        residential:
-          example: true
-          nullable: true
-          type: boolean
+      allOf:
+      - description: Address of the person who will receive the order
+        properties:
+          street1:
+            description: Street and number of the delivery address.
+            example: Nuevo Leon 254
+            maxLength: 250
+            type: string
+          street2:
+            description: "Apartment, suite or interior reference for the delivery\
+              \ address."
+            example: Departamento 404
+            maxLength: 250
+            type: string
+          postal_code:
+            description: Postal code of the delivery address. For Mexican addresses
+              (country MX) it must be a 5-digit postal code.
+            example: "06100"
+            maxLength: 250
+            type: string
+          city:
+            description: City of the delivery address.
+            example: Ciudad de Mexico
+            maxLength: 250
+            type: string
+          state:
+            description: State of the delivery address.
+            example: Ciudad de Mexico
+            maxLength: 250
+            type: string
+          country:
+            description: "Country of the delivery address. This field follows the\
+              \ [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)."
+            example: MX
+            maxLength: 250
+            type: string
+          residential:
+            default: true
+            description: Indicates whether the delivery address is residential.
+            example: true
+            nullable: true
+            type: boolean
+        title: shipping_contact_address
+      required:
+      - country
+      - postal_code
+      - street1
     customer_shipping_contacts_data_response:
       allOf:
       - description: |-
@@ -19314,14 +19336,17 @@ components:
             carrier:
               description: Carrier name for the shipment
               example: FEDEX
+              maxLength: 250
               type: string
             tracking_number:
               description: Tracking number can be used to track the shipment
               example: TRACK123
+              maxLength: 250
               type: string
             method:
               description: Method of shipment
               example: Same day
+              maxLength: 250
               type: string
             metadata:
               additionalProperties: true
@@ -19489,6 +19514,7 @@ components:
           brand:
             description: The brand of the item.
             example: Cohiba
+            maxLength: 250
             type: string
           description:
             description: Short description of the item
@@ -19507,6 +19533,7 @@ components:
           name:
             description: The name of the item. It will be displayed in the order.
             example: Box of Cohiba S1s
+            maxLength: 250
             type: string
           quantity:
             description: The quantity of the item in the order.
@@ -19518,6 +19545,7 @@ components:
             description: The stock keeping unit for the item. It is used to identify
               the item in the order.
             example: XYZ12345
+            maxLength: 250
             type: string
           tags:
             description: List of tags for the item. It is used to identify the item
@@ -19526,6 +19554,7 @@ components:
             - food
             - mexican food
             items:
+              maxLength: 250
               type: string
             type: array
             default: null
@@ -20060,6 +20089,7 @@ components:
         brand:
           description: The brand of the item.
           example: Cohiba
+          maxLength: 250
           type: string
         description:
           description: Short description of the item
@@ -20078,6 +20108,7 @@ components:
         name:
           description: The name of the item. It will be displayed in the order.
           example: Box of Cohiba S1s
+          maxLength: 250
           type: string
         quantity:
           description: The quantity of the item in the order.
@@ -20089,6 +20120,7 @@ components:
           description: The stock keeping unit for the item. It is used to identify
             the item in the order.
           example: XYZ12345
+          maxLength: 250
           type: string
         tags:
           description: List of tags for the item. It is used to identify the item
@@ -20097,6 +20129,7 @@ components:
           - food
           - mexican food
           items:
+            maxLength: 250
             type: string
           type: array
           default: null
@@ -20122,14 +20155,17 @@ components:
         carrier:
           description: Carrier name for the shipment
           example: FEDEX
+          maxLength: 250
           type: string
         tracking_number:
           description: Tracking number can be used to track the shipment
           example: TRACK123
+          maxLength: 250
           type: string
         method:
           description: Method of shipment
           example: Same day
+          maxLength: 250
           type: string
         metadata:
           additionalProperties: true
@@ -20366,6 +20402,7 @@ components:
           brand:
             description: The brand of the item.
             example: Cohiba
+            maxLength: 250
             type: string
           description:
             description: Short description of the item
@@ -20384,6 +20421,7 @@ components:
           name:
             description: The name of the item. It will be displayed in the order.
             example: Box of Cohiba S1s
+            maxLength: 250
             type: string
           quantity:
             description: The quantity of the item in the order.
@@ -20395,6 +20433,7 @@ components:
             description: The stock keeping unit for the item. It is used to identify
               the item in the order.
             example: XYZ12345
+            maxLength: 250
             type: string
           tags:
             description: List of tags for the item. It is used to identify the item
@@ -20403,6 +20442,7 @@ components:
             - food
             - mexican food
             items:
+              maxLength: 250
               type: string
             type: array
             default: null
@@ -21413,14 +21453,17 @@ components:
           carrier:
             description: Carrier name for the shipment
             example: FEDEX
+            maxLength: 250
             type: string
           tracking_number:
             description: Tracking number can be used to track the shipment
             example: TRACK123
+            maxLength: 250
             type: string
           method:
             description: Method of shipment
             example: Same day
+            maxLength: 250
             type: string
           metadata:
             additionalProperties: true
@@ -21481,6 +21524,48 @@ components:
           example: false
           type: boolean
       title: customer_shipping_contacts_response
+    shipping_contact_address:
+      description: Address of the person who will receive the order
+      properties:
+        street1:
+          description: Street and number of the delivery address.
+          example: Nuevo Leon 254
+          maxLength: 250
+          type: string
+        street2:
+          description: "Apartment, suite or interior reference for the delivery address."
+          example: Departamento 404
+          maxLength: 250
+          type: string
+        postal_code:
+          description: Postal code of the delivery address. For Mexican addresses
+            (country MX) it must be a 5-digit postal code.
+          example: "06100"
+          maxLength: 250
+          type: string
+        city:
+          description: City of the delivery address.
+          example: Ciudad de Mexico
+          maxLength: 250
+          type: string
+        state:
+          description: State of the delivery address.
+          example: Ciudad de Mexico
+          maxLength: 250
+          type: string
+        country:
+          description: "Country of the delivery address. This field follows the [ISO\
+            \ 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)."
+          example: MX
+          maxLength: 250
+          type: string
+        residential:
+          default: true
+          description: Indicates whether the delivery address is residential.
+          example: true
+          nullable: true
+          type: boolean
+      title: shipping_contact_address
     customer_update_shipping_contacts_request:
       description: |-
         [Shipping](https://developers.conekta.com/v2.3.0/reference/createcustomershippingcontacts)
@@ -21499,7 +21584,7 @@ components:
           example: Ackerman Crescent
           type: string
         address:
-          $ref: "#/components/schemas/customer_shipping_contacts_request_address"
+          $ref: "#/components/schemas/shipping_contact_address"
         parent_id:
           type: string
         default:

--- a/schemas/checkouts/checkout.yml
+++ b/schemas/checkouts/checkout.yml
@@ -25,11 +25,11 @@ properties:
   exclude_card_networks:
     title: checkout_exclude_card_networks
     type: array
-    description: "List of card networks to exclude from the checkout. This field is only applicable for card payments."
+    description: "List of card networks to exclude from the checkout. This field is only applicable for card payments. Accepted request values: 'visa_master_card' (a single token excluding both Visa and Mastercard) and 'amex'. Responses echo the stored values in CamelCase (e.g. 'VisaMasterCard', 'Amex')."
     items:
       type: string
-      enum: ["visa", "mastercard", "amex"]
-    example: ["visa", "amex"]
+      enum: ["visa_master_card", "amex", "VisaMasterCard", "Amex"]
+    example: ["visa_master_card"]
   expires_at:
     type: integer
     example: 1680397724
@@ -51,12 +51,15 @@ properties:
     example: [3,6,12]
   three_ds_mode:
     type: [string, "null"]
-    description: "Indicates the 3DS2 mode for the order, either smart or strict. This property is only applicable when 3DS is enabled. When 3DS is disabled, this field should be null."
+    enum: ["strict", "not_strict", "smart", null]
+    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. Accepted on creation only. This property is only applicable when 3DS is enabled; when 3DS is disabled this field should be null (no 3DS flow is applied)."
     examples:
       - value: "smart"
-        summary: "Those transactions that Conekta considers to present a risk to commerce will go through an additional verification flow (through 3DS2), provided that the issuing bank is compatible with this technology.If the transaction is not considered risky, it will continue its normal course, without going through 3DS2 authentication."
+        summary: "Risk-based 3DS: transactions that Conekta considers risky go through the 3DS2 verification flow (provided the issuing bank supports it); low-risk transactions continue without 3DS2 authentication."
       - value: "strict"
-        summary: "All transactions will require 3DS2 authentication as a complementary measure for the security of charges, except those that are rejected by our Anti-Fraud. The issuing bank must be compatible with 3DS2 technology."
+        summary: "All transactions require 3DS2 authentication as a complementary security measure, except those rejected by our Anti-Fraud. The issuing bank must support 3DS2."
+      - value: "not_strict"
+        summary: "The 3DS2 challenge is also always initiated; intended as the more lenient variant of 'strict' where authentication attempts may be accepted."
   name:
     type: string
     description: Reason for charge

--- a/schemas/checkouts/checkout.yml
+++ b/schemas/checkouts/checkout.yml
@@ -25,10 +25,10 @@ properties:
   exclude_card_networks:
     title: checkout_exclude_card_networks
     type: array
-    description: "List of card networks to exclude from the checkout. This field is only applicable for card payments. Accepted request values: 'visa_master_card' (a single token excluding both Visa and Mastercard) and 'amex'. Responses echo the stored values in CamelCase (e.g. 'VisaMasterCard', 'Amex')."
+    description: "List of card networks to exclude from the checkout. This field is only applicable for card payments. Accepted values: 'visa_master_card' (a single token excluding both Visa and Mastercard) and 'amex'."
     items:
       type: string
-      enum: ["visa_master_card", "amex", "VisaMasterCard", "Amex"]
+      enum: ["visa_master_card", "amex"]
     example: ["visa_master_card"]
   expires_at:
     type: integer
@@ -52,14 +52,14 @@ properties:
   three_ds_mode:
     type: [string, "null"]
     enum: ["strict", "not_strict", "smart", null]
-    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. Accepted on creation only. This property is only applicable when 3DS is enabled; when 3DS is disabled this field should be null (no 3DS flow is applied)."
+    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. Accepted on creation only. When this field is null the checkout defers to the company-level 3DS configuration."
     examples:
       - value: "smart"
         summary: "Risk-based 3DS: transactions that Conekta considers risky go through the 3DS2 verification flow (provided the issuing bank supports it); low-risk transactions continue without 3DS2 authentication."
       - value: "strict"
         summary: "All transactions require 3DS2 authentication as a complementary security measure, except those rejected by our Anti-Fraud. The issuing bank must support 3DS2."
       - value: "not_strict"
-        summary: "The 3DS2 challenge is also always initiated; intended as the more lenient variant of 'strict' where authentication attempts may be accepted."
+        summary: "The 3DS2 challenge is also always initiated, behaving like 'strict'. Acceptance of authentication attempts is governed by the company-level 3DS configuration, not by this mode."
   name:
     type: string
     description: Reason for charge

--- a/schemas/checkouts/checkout.yml
+++ b/schemas/checkouts/checkout.yml
@@ -50,9 +50,9 @@ properties:
       format: int8
     example: [3,6,12]
   three_ds_mode:
-    type: [string, "null"]
-    enum: ["strict", "not_strict", "smart", null]
-    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. Accepted on creation only. Null appears in responses when no mode is configured; to defer to the company-level 3DS configuration, omit the field on creation (an explicit null is rejected)."
+    type: string
+    enum: ["strict", "not_strict", "smart"]
+    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. To defer to the company-level 3DS configuration, omit the field (an explicit null is rejected on creation)."
     examples:
       - value: "smart"
         summary: "Risk-based 3DS: transactions that Conekta considers risky go through the 3DS2 verification flow (provided the issuing bank supports it); low-risk transactions continue without 3DS2 authentication."

--- a/schemas/checkouts/checkout.yml
+++ b/schemas/checkouts/checkout.yml
@@ -52,14 +52,14 @@ properties:
   three_ds_mode:
     type: [string, "null"]
     enum: ["strict", "not_strict", "smart", null]
-    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. Accepted on creation only. When this field is null the checkout defers to the company-level 3DS configuration."
+    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. Accepted on creation only. Null appears in responses when no mode is configured; to defer to the company-level 3DS configuration, omit the field on creation (an explicit null is rejected)."
     examples:
       - value: "smart"
         summary: "Risk-based 3DS: transactions that Conekta considers risky go through the 3DS2 verification flow (provided the issuing bank supports it); low-risk transactions continue without 3DS2 authentication."
       - value: "strict"
         summary: "All transactions require 3DS2 authentication as a complementary security measure, except those rejected by our Anti-Fraud. The issuing bank must support 3DS2."
       - value: "not_strict"
-        summary: "The 3DS2 challenge is also always initiated, behaving like 'strict'. Acceptance of authentication attempts is governed by the company-level 3DS configuration, not by this mode."
+        summary: "The 3DS2 flow is also always initiated, behaving like 'strict'. Acceptance of authentication attempts is governed by the company-level 3DS configuration, not by this mode."
   name:
     type: string
     description: Reason for charge

--- a/schemas/checkouts/checkout_request.yml
+++ b/schemas/checkouts/checkout_request.yml
@@ -20,11 +20,11 @@ properties:
   exclude_card_networks:
     title: checkout_request_exclude_card_networks
     type: array
-    description: "List of card networks to exclude from the checkout. This field is only applicable for card payments."
+    description: "List of card networks to exclude from the checkout. This field is only applicable for card payments. Accepted values: 'visa_master_card' (a single token excluding both Visa and Mastercard) and 'amex'. Values are echoed back in CamelCase (e.g. 'VisaMasterCard') in responses."
     items:
       type: string
-      enum: ["visa", "mastercard", "amex"]
-    example: ["visa", "amex"]
+      enum: ["visa_master_card", "amex"]
+    example: ["visa_master_card"]
   plan_ids:
     type: array
     description: "List of plan IDs that will be available for subscription. This field is required for subscription payments."

--- a/schemas/checkouts/checkout_request.yml
+++ b/schemas/checkouts/checkout_request.yml
@@ -20,7 +20,7 @@ properties:
   exclude_card_networks:
     title: checkout_request_exclude_card_networks
     type: array
-    description: "List of card networks to exclude from the checkout. This field is only applicable for card payments. Accepted values: 'visa_master_card' (a single token excluding both Visa and Mastercard) and 'amex'. Values are echoed back in CamelCase (e.g. 'VisaMasterCard') in responses."
+    description: "List of card networks to exclude from the checkout. This field is only applicable for card payments. Accepted values: 'visa_master_card' (a single token excluding both Visa and Mastercard) and 'amex'."
     items:
       type: string
       enum: ["visa_master_card", "amex"]

--- a/schemas/customers/customer_address.yml
+++ b/schemas/customers/customer_address.yml
@@ -23,10 +23,5 @@ properties:
     type: string
     example: MX
     description: "this field follows the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)"
-  residential:
-    type: boolean
-    example: true
-    default: false
   external_number:
     type: string
-    

--- a/schemas/customers/customer_shipping_contacts.yml
+++ b/schemas/customers/customer_shipping_contacts.yml
@@ -17,32 +17,13 @@ properties:
     type: string
     example: "Ackerman Crescent"
     description: "The street names between which the order will be delivered."
-  address: 
-    type: object
-    description: "Address of the person who will receive the order"
-    properties:
-      street1:
-        type: string
-        example: Nuevo Leon 254
-      street2: 
-        type: string
-        example: Departamento 404
-      postal_code:
-        type: string
-        example: "06100"
-      city: 
-        type: string
-        example: "Ciudad de Mexico"
-      state:
-        type: string
-        example: "Ciudad de Mexico"
-      country:
-        type: string
-        example: MX
-        description: "this field follows the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)"
-      residential:
-        type: [boolean, "null"]
-        example: true
+  address:
+    allOf:
+      - $ref: shipping_contact_address.yml
+    required:
+      - street1
+      - postal_code
+      - country
   parent_id:
     type: string
   default:

--- a/schemas/customers/customer_shipping_contacts.yml
+++ b/schemas/customers/customer_shipping_contacts.yml
@@ -13,10 +13,12 @@ properties:
     type: string
     example:   "Marvin Fuller"
     description: "Name of the person who will receive the order"
-  between_streets: 
+  between_streets:
     type: string
+    maxLength: 249
+    pattern: "[A-Za-z]{2}"
     example: "Ackerman Crescent"
-    description: "The street names between which the order will be delivered."
+    description: "The street names between which the order will be delivered. Must contain at least two consecutive ASCII letters."
   address:
     allOf:
       - $ref: shipping_contact_address.yml

--- a/schemas/customers/customer_update_shipping_contacts.yml
+++ b/schemas/customers/customer_update_shipping_contacts.yml
@@ -15,32 +15,8 @@ properties:
     type: string
     example: "Ackerman Crescent"
     description: "The street names between which the order will be delivered."
-  address: 
-    type: object
-    description: "Address of the person who will receive the order"
-    properties:
-      street1:
-        type: string
-        example: Nuevo Leon 254
-      street2: 
-        type: string
-        example: Departamento 404
-      postal_code:
-        type: string
-        example: "06100"
-      city: 
-        type: string
-        example: "Ciudad de Mexico"
-      state:
-        type: string
-        example: "Ciudad de Mexico"
-      country:
-        type: string
-        example: MX
-        description: "this field follows the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)"
-      residential:
-        type: [boolean, "null"]
-        example: true
+  address:
+    $ref: shipping_contact_address.yml
   parent_id:
     type: string
   default:

--- a/schemas/customers/customer_update_shipping_contacts.yml
+++ b/schemas/customers/customer_update_shipping_contacts.yml
@@ -11,10 +11,12 @@ properties:
     type: string
     example:   "Marvin Fuller"
     description: "Name of the person who will receive the order"
-  between_streets: 
+  between_streets:
     type: string
+    maxLength: 249
+    pattern: "[A-Za-z]{2}"
     example: "Ackerman Crescent"
-    description: "The street names between which the order will be delivered."
+    description: "The street names between which the order will be delivered. Must contain at least two consecutive ASCII letters."
   address:
     $ref: shipping_contact_address.yml
   parent_id:

--- a/schemas/customers/payment_method_bnpl_request.yml
+++ b/schemas/customers/payment_method_bnpl_request.yml
@@ -9,11 +9,11 @@ allOf:
         - type
     properties:
       cancel_url:
-        type: string
+        type: [string, "null"]
         description: "Optional URL to redirect the customer after a canceled payment"
         example: "https://example.com/cancel"
       expires_at:
-        type: integer
+        type: [integer, "null"]
         format: int64
         example: 1680397724
         description: "Optional expiry for the BNPL order, expressed in seconds since the Unix epoch. Defaults to one month from creation when omitted."

--- a/schemas/customers/payment_method_bnpl_request.yml
+++ b/schemas/customers/payment_method_bnpl_request.yml
@@ -9,11 +9,11 @@ allOf:
         - type
     properties:
       cancel_url:
-        type: [string, "null"]
+        type: string
         description: "Optional URL to redirect the customer after a canceled payment"
         example: "https://example.com/cancel"
       expires_at:
-        type: [integer, "null"]
+        type: integer
         format: int64
         example: 1680397724
         description: "Optional expiry for the BNPL order, expressed in seconds since the Unix epoch. Defaults to one month from creation when omitted."

--- a/schemas/customers/payment_method_bnpl_request.yml
+++ b/schemas/customers/payment_method_bnpl_request.yml
@@ -3,8 +3,6 @@ allOf:
   - $ref: './customer_payment_method_request.yml'
   - type: object
     required:
-        - can_not_expire
-        - cancel_url
         - failure_url
         - product_type
         - success_url
@@ -12,12 +10,13 @@ allOf:
     properties:
       cancel_url:
         type: string
-        description: "URL to redirect the customer after a canceled payment"
+        description: "Optional URL to redirect the customer after a canceled payment"
         example: "https://example.com/cancel"
-      can_not_expire:
-        type: boolean
-        example: true
-        description: "Indicates if the payment method can not expire"
+      expires_at:
+        type: integer
+        format: int64
+        example: 1680397724
+        description: "Optional expiry for the BNPL order, expressed in seconds since the Unix epoch"
       failure_url:
         type: string
         description: "URL to redirect the customer after a failed payment"

--- a/schemas/customers/payment_method_bnpl_request.yml
+++ b/schemas/customers/payment_method_bnpl_request.yml
@@ -16,7 +16,7 @@ allOf:
         type: integer
         format: int64
         example: 1680397724
-        description: "Optional expiry for the BNPL order, expressed in seconds since the Unix epoch"
+        description: "Optional expiry for the BNPL order, expressed in seconds since the Unix epoch. Defaults to one month from creation when omitted."
       failure_url:
         type: string
         description: "URL to redirect the customer after a failed payment"

--- a/schemas/customers/payment_method_card_request.yml
+++ b/schemas/customers/payment_method_card_request.yml
@@ -31,7 +31,7 @@ allOf:
         type: string
         maxLength: 249
         example: "John Doe"
-        description: "Cardholder name. Must include first and last name separated by a space; single-word names are rejected."
+        description: "Cardholder name. Must include first and last name separated by a space; single-word names are rejected. Letters only — digits and most symbols are rejected."
       number:
         type: string
         example: "4242424242424242"

--- a/schemas/customers/payment_method_card_request.yml
+++ b/schemas/customers/payment_method_card_request.yml
@@ -31,7 +31,7 @@ allOf:
         type: string
         maxLength: 249
         example: "John Doe"
-        description: "Cardholder name. Must include first and last name separated by a space; single-word names are rejected. Letters only — digits and most symbols are rejected."
+        description: "Cardholder name. Must include first and last name separated by a space; single-word names are rejected. Letters (including accented Latin characters), spaces, and the characters , . ' - are accepted; digits and other symbols are rejected."
       number:
         type: string
         example: "4242424242424242"

--- a/schemas/customers/payment_method_card_request.yml
+++ b/schemas/customers/payment_method_card_request.yml
@@ -29,12 +29,19 @@ allOf:
         minLength: 4
       name:
         type: string
+        maxLength: 249
         example: "John Doe"
-        description: "Cardholder name"
+        description: "Cardholder name. Must include first and last name separated by a space; single-word names are rejected."
       number:
         type: string
         example: "4242424242424242"
         description: "Card number"
+      contract_id:
+        type: string
+        minLength: 10
+        maxLength: 10
+        example: "3456788363"
+        description: "Optional merchant-supplied identifier (exactly 10 characters) that links a card transaction to a recurring/subscription contract at the acquiring bank. Forwarded to the bank gateway and stored on the resulting charge. Accepted on creation only; ignored on update. Do not place sensitive bank data here — the value is returned in charge responses."
       customer_ip_address:
         type: string
         example: "0.0.0.0"

--- a/schemas/customers/shipping_contact_address.yml
+++ b/schemas/customers/shipping_contact_address.yml
@@ -4,12 +4,13 @@ description: "Address of the person who will receive the order"
 properties:
   street1:
     type: string
-    maxLength: 250
+    minLength: 2
+    maxLength: 249
     example: Nuevo Leon 254
     description: "Street and number of the delivery address."
   street2:
     type: string
-    maxLength: 250
+    maxLength: 249
     example: Departamento 404
     description: "Apartment, suite or interior reference for the delivery address."
   postal_code:
@@ -19,17 +20,18 @@ properties:
     description: "Postal code of the delivery address. For Mexican addresses (country MX) it must be a 5-digit postal code."
   city:
     type: string
-    maxLength: 250
+    maxLength: 249
     example: "Ciudad de Mexico"
     description: "City of the delivery address."
   state:
     type: string
-    maxLength: 250
+    maxLength: 249
     example: "Ciudad de Mexico"
     description: "State of the delivery address."
   country:
     type: string
-    maxLength: 250
+    minLength: 2
+    maxLength: 249
     example: MX
     description: "Country of the delivery address. This field follows the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)."
   residential:

--- a/schemas/customers/shipping_contact_address.yml
+++ b/schemas/customers/shipping_contact_address.yml
@@ -1,0 +1,39 @@
+title: shipping_contact_address
+type: object
+description: "Address of the person who will receive the order"
+properties:
+  street1:
+    type: string
+    maxLength: 250
+    example: Nuevo Leon 254
+    description: "Street and number of the delivery address."
+  street2:
+    type: string
+    maxLength: 250
+    example: Departamento 404
+    description: "Apartment, suite or interior reference for the delivery address."
+  postal_code:
+    type: string
+    maxLength: 250
+    example: "06100"
+    description: "Postal code of the delivery address. For Mexican addresses (country MX) it must be a 5-digit postal code."
+  city:
+    type: string
+    maxLength: 250
+    example: "Ciudad de Mexico"
+    description: "City of the delivery address."
+  state:
+    type: string
+    maxLength: 250
+    example: "Ciudad de Mexico"
+    description: "State of the delivery address."
+  country:
+    type: string
+    maxLength: 250
+    example: MX
+    description: "Country of the delivery address. This field follows the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)."
+  residential:
+    type: [boolean, "null"]
+    default: true
+    example: true
+    description: "Indicates whether the delivery address is residential."

--- a/schemas/customers/shipping_contact_address.yml
+++ b/schemas/customers/shipping_contact_address.yml
@@ -21,8 +21,9 @@ properties:
   city:
     type: string
     maxLength: 249
+    pattern: "[A-Za-z]{2}"
     example: "Ciudad de Mexico"
-    description: "City of the delivery address."
+    description: "City of the delivery address. Must contain at least two consecutive ASCII letters."
   state:
     type: string
     maxLength: 249

--- a/schemas/orders/order_request.yml
+++ b/schemas/orders/order_request.yml
@@ -66,9 +66,15 @@ properties:
       $ref: product.yml
   metadata:
     type: object
-    additionalProperties: true
+    additionalProperties:
+      oneOf:
+        - type: string
+          maxLength: 249
+        - type: integer
+        - type: number
+        - type: boolean
     maxProperties: 100
-    description: "Metadata associated with the order"
+    description: "Metadata associated with the order. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are rejected."
   needs_shipping_contact:
     type: boolean
     example: false
@@ -99,9 +105,12 @@ properties:
       $ref: order_tax_request.yml
   three_ds_mode:
     type: [string, "null"]
-    description: "Indicates the 3DS2 mode for the order, either smart or strict. This property is only applicable when 3DS is enabled. When 3DS is disabled, this field should be null."
+    enum: ["strict", "not_strict", "smart", null]
+    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. Accepted on creation only. This property is only applicable when 3DS is enabled; when 3DS is disabled this field should be null (no 3DS flow is applied)."
     examples:
       - value: "smart"
-        summary: "Those transactions that Conekta considers to present a risk to commerce will go through an additional verification flow (through 3DS2), provided that the issuing bank is compatible with this technology.If the transaction is not considered risky, it will continue its normal course, without going through 3DS2 authentication."
+        summary: "Risk-based 3DS: transactions that Conekta considers risky go through the 3DS2 verification flow (provided the issuing bank supports it); low-risk transactions continue without 3DS2 authentication."
       - value: "strict"
-        summary: "All transactions will require 3DS2 authentication as a complementary measure for the security of charges, except those that are rejected by our Anti-Fraud. The issuing bank must be compatible with 3DS2 technology."
+        summary: "All transactions require 3DS2 authentication as a complementary security measure, except those rejected by our Anti-Fraud. The issuing bank must support 3DS2."
+      - value: "not_strict"
+        summary: "The 3DS2 challenge is also always initiated; intended as the more lenient variant of 'strict' where authentication attempts may be accepted."

--- a/schemas/orders/order_request.yml
+++ b/schemas/orders/order_request.yml
@@ -67,7 +67,7 @@ properties:
   metadata:
     type: object
     additionalProperties:
-      oneOf:
+      anyOf:
         - type: string
           maxLength: 249
         - type: integer
@@ -106,11 +106,11 @@ properties:
   three_ds_mode:
     type: [string, "null"]
     enum: ["strict", "not_strict", "smart", null]
-    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. Accepted on creation only. This property is only applicable when 3DS is enabled; when 3DS is disabled this field should be null (no 3DS flow is applied)."
+    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. The value is validated against the allowed set on creation. When this field is null the order defers to the company-level 3DS configuration."
     examples:
       - value: "smart"
         summary: "Risk-based 3DS: transactions that Conekta considers risky go through the 3DS2 verification flow (provided the issuing bank supports it); low-risk transactions continue without 3DS2 authentication."
       - value: "strict"
         summary: "All transactions require 3DS2 authentication as a complementary security measure, except those rejected by our Anti-Fraud. The issuing bank must support 3DS2."
       - value: "not_strict"
-        summary: "The 3DS2 challenge is also always initiated; intended as the more lenient variant of 'strict' where authentication attempts may be accepted."
+        summary: "The 3DS2 challenge is also always initiated, behaving like 'strict'. Acceptance of authentication attempts is governed by the company-level 3DS configuration, not by this mode."

--- a/schemas/orders/order_request.yml
+++ b/schemas/orders/order_request.yml
@@ -104,13 +104,13 @@ properties:
     items:
       $ref: order_tax_request.yml
   three_ds_mode:
-    type: [string, "null"]
-    enum: ["strict", "not_strict", "smart", null]
-    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. The value is validated against the allowed set on creation. When this field is null the order defers to the company-level 3DS configuration."
+    type: string
+    enum: ["strict", "not_strict", "smart"]
+    description: "Indicates the 3DS2 mode: 'strict', 'not_strict' or 'smart'. The value is validated against the allowed set on creation; sending an explicit null is rejected. Omit the field to create the order without requesting 3DS through the API (company-level 3DS applies only to orders paid through Checkout or when antifraud forces 3DS)."
     examples:
       - value: "smart"
         summary: "Risk-based 3DS: transactions that Conekta considers risky go through the 3DS2 verification flow (provided the issuing bank supports it); low-risk transactions continue without 3DS2 authentication."
       - value: "strict"
         summary: "All transactions require 3DS2 authentication as a complementary security measure, except those rejected by our Anti-Fraud. The issuing bank must support 3DS2."
       - value: "not_strict"
-        summary: "The 3DS2 challenge is also always initiated, behaving like 'strict'. Acceptance of authentication attempts is governed by the company-level 3DS configuration, not by this mode."
+        summary: "The 3DS2 flow is also always initiated, behaving like 'strict'. Acceptance of authentication attempts is governed by the company-level 3DS configuration, not by this mode."

--- a/schemas/orders/order_request.yml
+++ b/schemas/orders/order_request.yml
@@ -74,7 +74,7 @@ properties:
         - type: number
         - type: boolean
     maxProperties: 100
-    description: "Metadata associated with the order. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are rejected."
+    description: "Metadata associated with the order. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are not supported."
   needs_shipping_contact:
     type: boolean
     example: false

--- a/schemas/orders/order_tax_request.yml
+++ b/schemas/orders/order_tax_request.yml
@@ -18,6 +18,12 @@ properties:
     description: description or tax's name
   metadata:
     type: object
-    additionalProperties: true
+    additionalProperties:
+      oneOf:
+        - type: string
+          maxLength: 249
+        - type: integer
+        - type: number
+        - type: boolean
     example: { "key": "value" }
     maxProperties: 100

--- a/schemas/orders/order_tax_request.yml
+++ b/schemas/orders/order_tax_request.yml
@@ -19,7 +19,7 @@ properties:
   metadata:
     type: object
     additionalProperties:
-      oneOf:
+      anyOf:
         - type: string
           maxLength: 249
         - type: integer

--- a/schemas/orders/order_tax_request.yml
+++ b/schemas/orders/order_tax_request.yml
@@ -14,7 +14,7 @@ properties:
   description:
     type: string
     example: "testing"
-    minLength: 2
+    minLength: 3
     description: description or tax's name
   metadata:
     type: object

--- a/schemas/orders/order_update_request.yml
+++ b/schemas/orders/order_update_request.yml
@@ -63,7 +63,7 @@ properties:
     type: object
     maxProperties: 100
     additionalProperties:
-      oneOf:
+      anyOf:
         - type: string
           maxLength: 249
         - type: integer

--- a/schemas/orders/order_update_request.yml
+++ b/schemas/orders/order_update_request.yml
@@ -61,8 +61,14 @@ properties:
       $ref: product.yml
   metadata:
     type: object
+    maxProperties: 100
     additionalProperties:
-      type: string
+      oneOf:
+        - type: string
+          maxLength: 249
+        - type: integer
+        - type: number
+        - type: boolean
   pre_authorize:
     type: boolean
     description: "Indicates whether the order charges must be preauthorized"

--- a/schemas/orders/product.yml
+++ b/schemas/orders/product.yml
@@ -11,13 +11,15 @@ properties:
     example: { "key": "value" }
   brand:
     type: string
-    maxLength: 250
+    minLength: 2
+    maxLength: 249
     example: "Cohiba"
     description: "The brand of the item."
   description:
     type: string
     example: "Imported From Mex."
-    maxLength: 250
+    minLength: 3
+    maxLength: 249
     description: "Short description of the item"
   metadata:
     type: object
@@ -28,7 +30,8 @@ properties:
     default: {}
   name:
     type: string
-    maxLength: 250
+    minLength: 3
+    maxLength: 249
     example: "Box of Cohiba S1s"
     description: "The name of the item. It will be displayed in the order."
   quantity:
@@ -39,14 +42,17 @@ properties:
     description: "The quantity of the item in the order."
   sku:
     type: string
-    maxLength: 250
+    minLength: 1
+    maxLength: 249
     example: "XYZ12345"
     description: "The stock keeping unit for the item. It is used to identify the item in the order."
   tags:
     type: array
+    minItems: 1
     items:
       type: string
-      maxLength: 250
+      minLength: 2
+      maxLength: 249
     example: [ "food", "mexican food"]
     description: "List of tags for the item. It is used to identify the item in the order."
   unit_price: 

--- a/schemas/orders/product.yml
+++ b/schemas/orders/product.yml
@@ -11,6 +11,7 @@ properties:
     example: { "key": "value" }
   brand:
     type: string
+    maxLength: 250
     example: "Cohiba"
     description: "The brand of the item."
   description:
@@ -27,6 +28,7 @@ properties:
     default: {}
   name:
     type: string
+    maxLength: 250
     example: "Box of Cohiba S1s"
     description: "The name of the item. It will be displayed in the order."
   quantity:
@@ -37,12 +39,14 @@ properties:
     description: "The quantity of the item in the order."
   sku:
     type: string
+    maxLength: 250
     example: "XYZ12345"
     description: "The stock keeping unit for the item. It is used to identify the item in the order."
   tags:
     type: array
     items:
       type: string
+      maxLength: 250
     example: [ "food", "mexican food"]
     description: "List of tags for the item. It is used to identify the item in the order."
   unit_price: 

--- a/schemas/orders/product.yml
+++ b/schemas/orders/product.yml
@@ -26,7 +26,7 @@ properties:
     maxProperties: 100
     description: It is a key/value hash that can hold custom fields. Maximum 100 elements. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are rejected.
     additionalProperties:
-      oneOf:
+      anyOf:
         - type: string
           maxLength: 249
         - type: integer

--- a/schemas/orders/product.yml
+++ b/schemas/orders/product.yml
@@ -24,8 +24,14 @@ properties:
   metadata:
     type: object
     maxProperties: 100
-    description: It is a key/value hash that can hold custom fields. Maximum 100 elements and allows special characters.
-    additionalProperties: true
+    description: It is a key/value hash that can hold custom fields. Maximum 100 elements. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are rejected.
+    additionalProperties:
+      oneOf:
+        - type: string
+          maxLength: 249
+        - type: integer
+        - type: number
+        - type: boolean
     example: { "key": "value" }
     default: {}
   name:

--- a/schemas/orders/product.yml
+++ b/schemas/orders/product.yml
@@ -24,7 +24,7 @@ properties:
   metadata:
     type: object
     maxProperties: 100
-    description: It is a key/value hash that can hold custom fields. Maximum 100 elements. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are rejected.
+    description: It is a key/value hash that can hold custom fields. Maximum 100 elements. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are not supported.
     additionalProperties:
       anyOf:
         - type: string

--- a/schemas/orders/request_examples/charge_bnpl.yml
+++ b/schemas/orders/request_examples/charge_bnpl.yml
@@ -1,6 +1,5 @@
 value:
-  payment_method: 
-    can_not_expire: true
+  payment_method:
     cancel_url: https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/cancel
     failure_url:  https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/failure
     product_type: aplazo_bnpl

--- a/schemas/orders/request_examples/order_with_charges_bnpl.yml
+++ b/schemas/orders/request_examples/order_with_charges_bnpl.yml
@@ -6,7 +6,6 @@ value:
     checkout_request_type: "PaymentLink"
   charges:
     - payment_method:
-        can_not_expire: true
         cancel_url: "https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/cancel"
         failure_url: "https://pay.conekta.io/payment-status/fdcb06d6-c9e1-44ee-921f-17723b63852f/failure"
         product_type: "aplazo_bnpl"

--- a/schemas/orders/shipping_request.yml
+++ b/schemas/orders/shipping_request.yml
@@ -10,17 +10,20 @@ properties:
     description: Shipping amount in cents
   carrier:
     type: string
-    maxLength: 250
+    minLength: 3
+    maxLength: 249
     example: FEDEX
     description: Carrier name for the shipment
   tracking_number:
     type: string
-    maxLength: 250
+    minLength: 3
+    maxLength: 249
     example: "TRACK123"
     description: Tracking number can be used to track the shipment
   method:
     type: string
-    maxLength: 250
+    minLength: 3
+    maxLength: 249
     example: "Same day"
     description: Method of shipment
   metadata:

--- a/schemas/orders/shipping_request.yml
+++ b/schemas/orders/shipping_request.yml
@@ -8,17 +8,20 @@ properties:
     example: 100
     minimum: 0
     description: Shipping amount in cents
-  carrier: 
+  carrier:
     type: string
+    maxLength: 250
     example: FEDEX
     description: Carrier name for the shipment
   tracking_number:
     type: string
+    maxLength: 250
     example: "TRACK123"
     description: Tracking number can be used to track the shipment
   method:
     type: string
-    example: "Same day" 
+    maxLength: 250
+    example: "Same day"
     description: Method of shipment
   metadata:
     description: Hash where the user can send additional information for each 'shipping'.

--- a/schemas/orders/shipping_request.yml
+++ b/schemas/orders/shipping_request.yml
@@ -27,7 +27,7 @@ properties:
     example: "Same day"
     description: Method of shipment
   metadata:
-    description: Hash where the user can send additional information for each 'shipping'. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are rejected.
+    description: Hash where the user can send additional information for each 'shipping'. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are not supported.
     type: object
     additionalProperties:
       anyOf:

--- a/schemas/orders/shipping_request.yml
+++ b/schemas/orders/shipping_request.yml
@@ -30,7 +30,7 @@ properties:
     description: Hash where the user can send additional information for each 'shipping'. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are rejected.
     type: object
     additionalProperties:
-      oneOf:
+      anyOf:
         - type: string
           maxLength: 249
         - type: integer

--- a/schemas/orders/shipping_request.yml
+++ b/schemas/orders/shipping_request.yml
@@ -27,8 +27,14 @@ properties:
     example: "Same day"
     description: Method of shipment
   metadata:
-    description: Hash where the user can send additional information for each 'shipping'.
+    description: Hash where the user can send additional information for each 'shipping'. Values must be scalar (string of at most 249 characters, integer, number or boolean); nested objects and arrays are rejected.
     type: object
-    additionalProperties: true
+    additionalProperties:
+      oneOf:
+        - type: string
+          maxLength: 249
+        - type: integer
+        - type: number
+        - type: boolean
     example: { "key": "value" }
     maxProperties: 100

--- a/schemas/orders/update_order_tax_request.yml
+++ b/schemas/orders/update_order_tax_request.yml
@@ -10,7 +10,7 @@ properties:
   description:
     type: string
     example: "testing"
-    minLength: 2
+    minLength: 3
     description: description or tax's name
   metadata:
     type: object

--- a/schemas/orders/update_order_tax_request.yml
+++ b/schemas/orders/update_order_tax_request.yml
@@ -15,5 +15,10 @@ properties:
   metadata:
     type: object
     additionalProperties:
-      type: object
+      oneOf:
+        - type: string
+          maxLength: 249
+        - type: integer
+        - type: number
+        - type: boolean
     maxProperties: 100

--- a/schemas/orders/update_order_tax_request.yml
+++ b/schemas/orders/update_order_tax_request.yml
@@ -15,7 +15,7 @@ properties:
   metadata:
     type: object
     additionalProperties:
-      oneOf:
+      anyOf:
         - type: string
           maxLength: 249
         - type: integer

--- a/schemas/orders/update_product.yml
+++ b/schemas/orders/update_product.yml
@@ -7,11 +7,16 @@ properties:
       type: object
   description:
     type: string
-    maxLength: 250
+    minLength: 3
+    maxLength: 249
   sku:
     type: string
+    minLength: 1
+    maxLength: 249
   name:
     type: string
+    minLength: 3
+    maxLength: 249
     example: "Box of Cohiba S1s"
   unit_price: 
     type: integer
@@ -25,10 +30,15 @@ properties:
     minimum: 1
   tags:
     type: array
+    minItems: 1
     items:
       type: string
+      minLength: 2
+      maxLength: 249
   brand:
     type: string
+    minLength: 2
+    maxLength: 249
   metadata:
     type: object
     additionalProperties:

--- a/schemas/orders/update_product.yml
+++ b/schemas/orders/update_product.yml
@@ -41,5 +41,11 @@ properties:
     maxLength: 249
   metadata:
     type: object
+    maxProperties: 100
     additionalProperties:
-      type: string
+      oneOf:
+        - type: string
+          maxLength: 249
+        - type: integer
+        - type: number
+        - type: boolean

--- a/schemas/orders/update_product.yml
+++ b/schemas/orders/update_product.yml
@@ -43,7 +43,7 @@ properties:
     type: object
     maxProperties: 100
     additionalProperties:
-      oneOf:
+      anyOf:
         - type: string
           maxLength: 249
         - type: integer


### PR DESCRIPTION
## Summary

Aligns the OpenAPI schemas for order **shipping address**, **shipping line**, **line item**, **checkout**, **card/BNPL payment methods**, and **metadata** with the validations actually enforced by `payments-api`'s sanitizers at v2.3.0. Every constraint was verified against payments-api source, then adversarially re-reviewed by four independent passes that re-derived each bound from code; their confirmed findings are incorporated.

Targets `release/v2.3.0`.

## Changes

**Shipping (original scope)**
- Shared `schemas/customers/shipping_contact_address.yml`; create requires `street1`/`postal_code`/`country` (update does not); MX 5-digit postal-code rule; min/max lengths per the strict `StringValidator` bounds (max = `less_than` − 1 = **249**; min = `greater_than` + 1). `postal_code` keeps **250** (its only cap is the inclusive model-level `zip` rule). City documents the enforced two-consecutive-letters pattern.

**Checkout / order (validated with team rulings)**
- `exclude_card_networks` enum → `[visa_master_card, amex]` (exact-membership validator; `visa`/`mastercard` are rejected). Responses return snake_case — an earlier CamelCase-echo claim was refuted in adversarial review (`Checkout.to_snake_case` underscores values on every read) and removed.
- `three_ds_mode` → adds accepted value `not_strict`; null defers to company-level 3DS configuration (it does not disable 3DS); `not_strict` is behaviorally identical to `strict` in payments-api (attempt acceptance is company-config, not mode). Create-only wording kept for checkouts (update cleaner permits nothing) and dropped for orders (permitted+persisted on update, validated on create).
- Order/line-item/tax/shipping metadata: values documented as scalar `string(≤249)/integer/number/boolean` via **`anyOf`** (adversarial review caught that `oneOf` rejects integers, which match both `integer` and `number`). Worded as "not supported" rather than "rejected": per team direction payments-api keeps its current partial per-key enforcement, so the docs state the contract without over-promising server-side rejection.
- `maxProperties: 100` retained/extended as the documented contract. **Known gap:** payments-api does not enforce it (characterization specs pinning this landed in conekta/payments-api#6466); closing it is a future product decision.

**Payment methods**
- BNPL: `cancel_url` is optional by design (spec-pinned in payments-api); `can_not_expire` removed (silently stripped by the cleaner); `expires_at` added (unix seconds; defaults to one month). Note: its datatype is currently unvalidated server-side (non-Integer 500s) — documented contract is integer.
- Card: two-word cardholder `name` rule (letters only) + `maxLength: 249`; `contract_id` exposed (exactly 10 chars, create-only, stored as `bank_contract_id`, echoed in charge responses since v2.1.0; carries a do-not-put-sensitive-data caveat).
- Fiscal entity address: `residential` removed — stripped by the cleaner and not storable on `FiscalEntityAddress` (the field exists only on `ShippingAddress`).

## Verification
- `make merge` rebuilds cleanly; bundler deduplicates the metadata value schema into a single shared component.
- Adversarial review: 4 independent passes over the full diff, every constraint re-derived from payments-api source with file:line proof. Findings fixed: `oneOf`→`anyOf`, CamelCase echo claim removed, order `three_ds_mode` create-only wording dropped, null semantics corrected, `not_strict` description made honest, city pattern documented.

## Related
- conekta/payments-api#6466 — characterization specs pinning the documented-but-unenforced gaps (metadata cap, per-key nested checks, BNPL types). Specs only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)