### PR TITLE
feat(msi): add POST /monthly_installments/validate to the spec

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -68,6 +68,8 @@ paths:
     $ref: "./resources/logs/log.yml"
   /logs/{id}:
     $ref: "./resources/logs/log_by_id.yml"
+  /monthly_installments/validate:
+    $ref: "./resources/monthly_installments/monthly_installments_validate.yml"
   /orders:
     $ref: "./resources/orders/order.yml"
   /orders/{id}:

--- a/requestBodies/monthly_installments/monthly_installments_validate.yml
+++ b/requestBodies/monthly_installments/monthly_installments_validate.yml
@@ -1,0 +1,6 @@
+description: requested field for monthly installments validate
+content:
+  application/json:
+    schema:
+      $ref: '../../schemas/monthly_installments/monthly_installments_validate.yml'
+required: true

--- a/resources/monthly_installments/monthly_installments_validate.yml
+++ b/resources/monthly_installments/monthly_installments_validate.yml
@@ -1,0 +1,51 @@
+post:
+  tags:
+    - Monthly Installments
+  operationId: validateMonthlyInstallments
+  summary: Validate Monthly Installments
+  description: |
+    Returns the interest-free monthly installment plans available for a card BIN and an amount, so a checkout can offer only the plans a later charge will accept. Requires monthly installments to be enabled on the company.
+  responses:
+    200:
+      description: successful operation
+      content:
+        application/vnd.conekta-v2.3.0+json:
+          schema:
+            $ref: '../../schemas/monthly_installments/monthly_installments_validate_response.yml'
+      headers:
+        Date:
+          description: The date and time that the response was sent
+          schema:
+            type: string
+            example: "Fri, 03 Feb 2023 16:57:48 GMT"
+        Content-Type:
+          description: The format of the response body
+          schema:
+            type: string
+            example: "application/json; charset=utf-8"
+        Content-Length:
+          description: The length of the response body in bytes
+          schema:
+            type: string
+            example: "245"
+        Connection:
+          description: The type of connection used to transfer the response
+          schema:
+            type: string
+            example: "keep-alive"
+        Conekta-Media-Type:
+          schema:
+            type: string
+            example: conekta-v2.3.0; format=application/json
+    401:
+     $ref: '../errors/401.yml'
+    422:
+     $ref: '../errors/422.yml'
+    500:
+     $ref: '../errors/500.yml'
+  security:
+    - bearerAuth: []
+  requestBody:
+   $ref: '../../requestBodies/monthly_installments/monthly_installments_validate.yml'
+  parameters:
+    - $ref: '../../parameters/commons/headers/accept_language.yml'

--- a/schemas/monthly_installments/monthly_installments_validate.yml
+++ b/schemas/monthly_installments/monthly_installments_validate.yml
@@ -1,0 +1,18 @@
+title: monthly installments validate request
+description: BIN and amount to evaluate for interest-free monthly installments
+type: object
+required:
+  - bin
+  - amount
+properties:
+  bin:
+    type: string
+    description: "First 6 or 8 digits of the card number (Bank Identification Number). An 8 digit BIN that yields no match is retried with its first 6 digits."
+    example: "411111"
+    minLength: 6
+    maxLength: 8
+    pattern: '^[0-9]{6}(?:[0-9]{2})?$'
+  amount:
+    type: integer
+    description: "Amount to charge in the smallest currency unit (cents for MXN). Used to compute the monthly fee of each available plan."
+    example: 350000

--- a/schemas/monthly_installments/monthly_installments_validate_response.yml
+++ b/schemas/monthly_installments/monthly_installments_validate_response.yml
@@ -1,0 +1,44 @@
+title: monthly_installments_validate_response
+description: monthly installments validate response
+type: object
+required:
+  - available_installments
+  - bin_info
+properties:
+  available_installments:
+    title: monthly_installments_validate_response_available_installments
+    type: array
+    description: "Interest-free monthly installment plans available for this card and amount. Empty when the card does not qualify for monthly installments, for example a debit card or a credit card not issued in Mexico. An empty array is not an error."
+    items:
+      type: object
+      required:
+        - months
+        - amount
+      properties:
+        months:
+          type: integer
+          description: "Number of monthly installments of the plan. One of 3, 6, 9, 12, 18 or 24."
+          example: 3
+        amount:
+          type: integer
+          description: "Amount of each monthly installment in the smallest currency unit, rounded up."
+          example: 116667
+  bin_info:
+    type: object
+    required:
+      - country
+      - scheme
+      - issuer
+    properties:
+      country:
+        type: string
+        description: "Country that issued the card. Monthly installments only apply to mx, with the exception of American Express."
+        example: "mx"
+      scheme:
+        type: string
+        description: "Card scheme. Monthly installments only apply to credit."
+        example: "credit"
+      issuer:
+        type: string
+        description: "Bank that issued the card."
+        example: "banamex"


### PR DESCRIPTION
## What

Adds `POST /monthly_installments/validate` to the spec. The endpoint exists and the public dev center documents it, but it is absent here, so no SDK exposes it.

- `payments-api` `config/routes.rb:736` → `MonthlyInstallmentsController#validate`
- Documented publicly at `dev-center` `docs/PAGOS A LA MEDIDA CON DIRECT API/aceptar-pagos-con-tarjetas-1/meses-sin-intereses-api.md` as **step 1** of the Direct API MSI flow, with a curl example and a full field table

Merchants are currently told to call an endpoint their SDK has no method for.

## Schema derivation

Everything comes from `BinValidatorService`, not from the docs:

| Field | Source |
|---|---|
| `bin` — 6 or 8 digits, 8 retried as 6 on no match | `BIN_SIZE = 8`; `#load_bin_information_with_fallback` (`@bin = bin[0..5]`) |
| `amount` — minor units | `#calculate_monthly_installments` (`amount / months.to_f`) |
| `available_installments[].months` / `.amount` | `#calculate_monthly_installments`, `#adapt_engine_options` (`monthly_fee` → `amount`) |
| `bin_info` — `country`, `scheme`, `issuer` | `#bin_info_summary` (exactly these three keys) |
| both top-level keys always present | `#retrieve_legacy` and `#retrieve_via_engine` both return the same two keys |
| `months` ∈ {3, 6, 9, 12, 18, 24} | `MONTHLY_INSTALLMENTS = [3, 6, 9, 12, 18, 24]` |

`available_installments` is documented as **legitimately empty** rather than an error case: `#retrieve_monthly_installments` returns `[]` when `validate_card_rules?` fails (debit, or credit not issued in Mexico). Client code that treats "no error" as "MSI available" will offer plazos the charge then rejects. Same note is going into the dev center in conekta/dev-center#55.

## Verification

`resources/`, `requestBodies/` and `schemas/` follow the `tokens/` layout exactly. Every `$ref` reachable from `api.yaml` resolves and every file parses — 276 files walked.

`_build/api.yaml` is **not** regenerated: `make merge` needs a running Docker daemon and none was available here. **Run `make merge` before merging.**

## Why this is a draft — please confirm the endpoint is public surface

`MonthlyInstallmentsController` carries the comment *"Add MSI validation for checkout-fe"*. It was built for Conekta's own checkout frontend, and adding it here generates public SDK methods in every language, which is a commitment to its stability. Two ways to resolve, and it is your call which:

1. It is public surface (the dev center already treats it as such) → merge this.
2. It is internal → close this, and the MSI page in the dev center should stop telling merchants to call it.

Either way the current state is inconsistent.

## Two other spec gaps I found and did NOT add

Both exist in `payments-api` and appear in public dev center pages, but I have no evidence they are *intended* as public API surface, and I will not invent a contract for them:

- `POST /payees` — `config/routes.rb:495`, under `ApiConstraints` version scoping, so which API versions expose it also needs confirming. Appears in `generar-una-dispersión-a-terceros-con-direct-api.md:79`.
- `PUT` / `GET /checkout_configuration` — `config/routes.rb:383`. Appears in `hosted-payments.md:905`.

Worth a decision alongside this one.